### PR TITLE
Disabled panning during mouse wheel zooming & fixed broken Firefox zo…

### DIFF
--- a/resources/js/views/global/SmoothWheelZoom.js
+++ b/resources/js/views/global/SmoothWheelZoom.js
@@ -14,11 +14,11 @@ L.Map.mergeOptions({
 L.Map.SmoothWheelZoom = L.Handler.extend({
 
     addHooks: function () {
-        L.DomEvent.on(this._map._container, 'mousewheel', this._onWheelScroll, this);
+        L.DomEvent.on(this._map._container, 'wheel', this._onWheelScroll, this);
     },
 
     removeHooks: function () {
-        L.DomEvent.off(this._map._container, 'mousewheel', this._onWheelScroll, this);
+        L.DomEvent.off(this._map._container, 'wheel', this._onWheelScroll, this);
     },
 
     _onWheelScroll: function (e) {
@@ -56,7 +56,6 @@ L.Map.SmoothWheelZoom = L.Handler.extend({
         if (this._goalZoom < map.getMinZoom() || this._goalZoom > map.getMaxZoom()) {
             this._goalZoom = map._limitZoom(this._goalZoom);
         }
-        this._wheelMousePosition = this._map.mouseEventToContainerPoint(e);
 
         clearTimeout(this._timeoutId);
         this._timeoutId = setTimeout(this._onWheelEnd.bind(this), 200);


### PR DESCRIPTION
…oming

1) This addresses issue #72

2) Mouse wheel zooming wasn't working on Firefox, because the non-standard 'mousewheel' event was being used, which Firefox does not support. See: https://developer.mozilla.org/en-US/docs/Web/API/Element/mousewheel_event

I've switched it to the standard 'wheel' event instead. Tested on Firefox, Chrome, Edge & Opera (all on Windows) 