### PR TITLE
Bug/broken migrations init setup

### DIFF
--- a/database/migrations/2021_01_23_182830_change_user_total_category_names.php
+++ b/database/migrations/2021_01_23_182830_change_user_total_category_names.php
@@ -18,11 +18,6 @@ class ChangeUserTotalCategoryNames extends Migration
             $table->unsignedBigInteger('total_dumping')->nullable();
             $table->unsignedBigInteger('total_industrial')->nullable();
             $table->unsignedBigInteger('total_coastal')->nullable();
-            $table->dropColumn('total_drugs');
-            $table->dropColumn('total_needles');
-            $table->dropColumn('total_cigaretteButts');
-            $table->dropColumn('total_plasticBottles');
-            $table->dropColumn('total_pathways');
         });
     }
 

--- a/database/migrations/2021_03_23_210323_create_permission_tables.php
+++ b/database/migrations/2021_03_23_210323_create_permission_tables.php
@@ -16,7 +16,7 @@ class CreatePermissionTables extends Migration
         $tableNames = config('permission.table_names');
         $columnNames = config('permission.column_names');
 
-//        Schema::rename('roles', 'old_roles');
+       Schema::rename('roles', 'old_roles');
 
         if (empty($tableNames)) {
             throw new \Exception('Error: config/permission.php not loaded. Run [php artisan config:clear] and try again.');


### PR DESCRIPTION
Fixing some minor issues with migrations. This will prevent that new local setups brake when migrating tables for the first time.