### PR TITLE
Added Levels seeder

### DIFF
--- a/app/Level.php
+++ b/app/Level.php
@@ -2,10 +2,13 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Level extends Model
 {
+    use HasFactory;
+
     protected $fillable = ['xp', 'level'];
     protected $table = 'levels';
 }

--- a/app/Models/Teams/TeamType.php
+++ b/app/Models/Teams/TeamType.php
@@ -2,10 +2,13 @@
 
 namespace App\Models\Teams;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class TeamType extends Model
 {
+    use HasFactory;
+
     protected $casts = [
     	'price' => 'integer'
     ];

--- a/database/factories/LevelFactory.php
+++ b/database/factories/LevelFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Level;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class LevelFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Level::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'xp' => $this->faker->randomElement([10, 50, 100, 1000, 10000, 100000]),
+            'level' => $this->faker->randomDigit
+        ];
+    }
+}

--- a/database/factories/Teams/TeamTypeFactory.php
+++ b/database/factories/Teams/TeamTypeFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories\Teams;
+
+use App\Models\Teams\TeamType;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TeamTypeFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = TeamType::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'team' => $this->faker->name,
+            'price' => $this->faker->randomDigit,
+            'description' => $this->faker->paragraph
+        ];
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -15,5 +15,6 @@ class DatabaseSeeder extends Seeder
     {
         $this->call(PlanSeeder::class);
         $this->call(DonationAmountsSeeder::class);
+        $this->call(LevelSeeder::class);
     }
 }

--- a/database/seeds/LevelSeeder.php
+++ b/database/seeds/LevelSeeder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class LevelSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('levels')->insert([
+            'xp' => 10,
+            'level' => 1,
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+        DB::table('levels')->insert([
+            'xp' => 50,
+            'level' => 2,
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+        DB::table('levels')->insert([
+            'xp' => 100,
+            'level' => 3,
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+        DB::table('levels')->insert([
+            'xp' => 500,
+            'level' => 4,
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+        DB::table('levels')->insert([
+            'xp' => 2000,
+            'level' => 5,
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+    }
+}

--- a/database/seeds/TeamTypeSeeder.php
+++ b/database/seeds/TeamTypeSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class TeamTypeSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('team_types')->insert([
+            'team' => 'Community',
+            'price' => 0,
+            'description' => 'A community of like-minded individuals',
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+    }
+}


### PR DESCRIPTION
On new setups, there's a console error on the user profile page, caused by the empty Levels table. This seed adds some default levels: 

1. 10 xp
2. 50 xp
3. 100 xp
4. 500 xp
5. 2000 xp


Also added a seeder for Team Types, it only adds a new team called Community. Helpful for new setups.