### PR TITLE
Added API route to upload photos with tags

### DIFF
--- a/app/Http/Controllers/ApiPhotosController.php
+++ b/app/Http/Controllers/ApiPhotosController.php
@@ -7,7 +7,6 @@ use App\Actions\Photos\MakeImageAction;
 use App\Actions\Locations\ReverseGeocodeLocationAction;
 use App\Actions\Photos\UploadPhotoAction;
 use App\Events\ImageDeleted;
-use App\Http\Requests\AddTagsApiRequest;
 use App\Models\Photo;
 use GeoHash;
 use Carbon\Carbon;
@@ -107,6 +106,125 @@ class ApiPhotosController extends Controller
             return ['success' => false, 'msg' => 'error-3'];
         }
 
+        $photo = $this->storePhoto($request);
+
+        return ['success' => true, 'photo_id' => $photo->id];
+    }
+
+    /**
+     * Upload Photo together with its tags
+     *
+     * @param Request $request
+     * @return array
+     * @throws GuzzleException
+     */
+    public function storeWithTags (Request $request) :array
+    {
+        $request->validate([
+            'photo' => 'required|mimes:jpg,png,jpeg',
+            'lat' => 'required|numeric',
+            'lon' => 'required|numeric',
+            'date' => 'required',
+            'tags' => 'required|array'
+        ]);
+
+        $file = $request->file('photo');
+
+        if ($file->getError() === 3)
+        {
+            return ['success' => false, 'msg' => 'error-3'];
+        }
+
+        $photo = $this->storePhoto($request);
+
+        $userId = Auth::guard('api')->user()->id;
+
+        dispatch (new AddTags($userId, $photo->id, $request->tags));
+
+        return ['success' => true, 'photo_id' => $photo->id];
+    }
+
+    /**
+     * Save litter data to a recently uploaded photo
+     *
+     * version 2
+     *
+     * This is used by gallery photos
+     */
+    public function addTags (Request $request)
+    {
+        $userId = Auth::guard('api')->user()->id;
+
+        Log::channel('tags')->info([
+            'add_tags' => 'mobile',
+            'request' => $request->all()
+        ]);
+
+        dispatch (new AddTags($userId, $request->photo_id, $request->litter));
+
+        return ['success' => true, 'msg' => 'dispatched'];
+    }
+
+    /**
+     * Check if the user has any available photos that are uploaded, but not tagged
+     */
+    public function check ()
+    {
+        $user = Auth::guard('api')->user();
+
+        $photos = $user->photos()
+            ->where('verified', 0)
+            ->where('verification', 0)
+            ->select('id', 'filename')
+            ->get();
+
+        return ['photos' => $photos];
+    }
+
+    /**
+     * Delete an image
+     */
+    public function deleteImage(Request $request)
+    {
+        $user = Auth::guard('api')->user();
+
+        $photo = Photo::findOrFail($request->photoId);
+
+        if ($user->id !== $photo->user_id) {
+            abort(403);
+        }
+
+        $this->deletePhotoAction->run($photo);
+
+        $photo->delete();
+
+        $user->xp = $user->xp > 0 ? $user->xp - 1 : 0;
+        $user->total_images = $user->total_images > 0 ? $user->total_images - 1 : 0;
+        $user->save();
+
+        event(new ImageDeleted(
+            $user,
+            $photo->country_id,
+            $photo->state_id,
+            $photo->city_id,
+            $photo->team_id
+        ));
+
+        return ['success' => true];
+    }
+
+    /**
+     * Temporary method to store a photo
+     * should be refactored back to the store method
+     * This is to handle all APIs from mobile app versions
+     *
+     * @param Request $request
+     * @return mixed
+     * @throws GuzzleException
+     */
+    protected function storePhoto(Request $request)
+    {
+        $file = $request->file('photo');
         $user = Auth::guard('api')->user();
 
         if (!$user->has_uploaded) $user->has_uploaded = 1;
@@ -122,9 +240,9 @@ class ApiPhotosController extends Controller
 
         $image = $this->makeImageAction->run($file);
 
-        $lat  = $request['lat'];
-		$lon  = $request['lon'];
-		$date = Carbon::parse($request['date']);
+        $lat = $request['lat'];
+        $lon = $request['lon'];
+        $date = Carbon::parse($request['date']);
 
         // Upload images to both 's3' and 'bbox' disks, resized for 'bbox'
         $imageName = $this->uploadPhotoAction->run(
@@ -191,7 +309,7 @@ class ApiPhotosController extends Controller
         if ($user->team) $teamName = $user->team->name;
 
         // Broadcast an event to anyone viewing the Global Map
-        event (new ImageUploaded(
+        event(new ImageUploaded(
             $city->city,
             $state->state,
             $country->country,
@@ -213,82 +331,6 @@ class ApiPhotosController extends Controller
             $city->id,
             $date
         ));
-
-		return ['success' => true, 'photo_id' => $photo->id];
-    }
-
-    /**
-     * Save litter data to a recently uploaded photo
-     *
-     * version 2
-     *
-     * This is used by gallery photos
-     */
-    public function addTags (AddTagsApiRequest $request)
-    {
-        $user = Auth::guard('api')->user();
-        $photo = Photo::find($request->photo_id);
-
-        if ($photo->user_id !== $user->id || $photo->verified > 0)
-        {
-            abort(403, 'Forbidden');
-        }
-
-        Log::channel('tags')->info([
-            'add_tags' => 'mobile',
-            'request' => $request->all()
-        ]);
-
-        dispatch (new AddTags($request->all(), $user->id));
-
-        return ['success' => true, 'msg' => 'dispatched'];
-    }
-
-    /**
-     * Check if the user has any available photos that are uploaded, but not tagged
-     */
-    public function check ()
-    {
-        $user = Auth::guard('api')->user();
-
-        $photos = $user->photos()
-            ->where('verified', 0)
-            ->where('verification', 0)
-            ->select('id', 'filename')
-            ->get();
-
-        return ['photos' => $photos];
-    }
-
-    /**
-     * Delete an image
-     */
-    public function deleteImage(Request $request)
-    {
-        $user = Auth::guard('api')->user();
-
-        $photo = Photo::findOrFail($request->photoId);
-
-        if ($user->id !== $photo->user_id) {
-            abort(403);
-        }
-
-        $this->deletePhotoAction->run($photo);
-
-        $photo->delete();
-
-        $user->xp = $user->xp > 0 ? $user->xp - 1 : 0;
-        $user->total_images = $user->total_images > 0 ? $user->total_images - 1 : 0;
-        $user->save();
-
-        event(new ImageDeleted(
-            $user,
-            $photo->country_id,
-            $photo->state_id,
-            $photo->city_id,
-            $photo->team_id
-        ));
-
-        return ['success' => true];
+        return $photo;
     }
 }

--- a/app/Jobs/Api/AddTags.php
+++ b/app/Jobs/Api/AddTags.php
@@ -20,17 +20,22 @@ class AddTags implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public $request, $userId;
+    public $userId;
+    public $photoId;
+    public $tags;
 
     /**
      * Create a new job instance.
      *
-     * @return void
+     * @param $userId
+     * @param $photoId
+     * @param $tags
      */
-    public function __construct ($request, $userId)
+    public function __construct ($userId, $photoId, $tags)
     {
-        $this->request = $request;
         $this->userId = $userId;
+        $this->photoId = $photoId;
+        $this->tags = $tags;
     }
 
     /**
@@ -42,13 +47,11 @@ class AddTags implements ShouldQueue
     {
         $user = User::find($this->userId);
 
-        $photo = Photo::find($this->request['photo_id']);
-
-        $tags = $this->request['litter'];
+        $photo = Photo::find($this->photoId);
 
         /** @var AddTagsToPhotoAction $addTagsAction */
         $addTagsAction = app(AddTagsToPhotoAction::class);
-        $litterTotals = $addTagsAction->run($photo, $tags);
+        $litterTotals = $addTagsAction->run($photo, $this->tags);
 
         $user->xp += $litterTotals['all'];
         $user->save();

--- a/routes/api.php
+++ b/routes/api.php
@@ -49,6 +49,10 @@ Route::post('/password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail
 // Upload Photos
 Route::post('/photos/submit', 'ApiPhotosController@store');
 
+// Upload Photos with tags
+Route::post('/photos/submit-with-tags', 'ApiPhotosController@storeWithTags')
+    ->middleware('auth:api');
+
 // Delete Photos
 Route::delete('/photos/delete', 'ApiPhotosController@deleteImage');
 

--- a/tests/Feature/Api/UploadPhotoWithTagsTest.php
+++ b/tests/Feature/Api/UploadPhotoWithTagsTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Events\ImageUploaded;
+use App\Events\Photo\IncrementPhotoMonth;
+use App\Models\Litter\Categories\Smoking;
+use App\Models\Teams\Team;
+use App\Models\User\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Storage;
+use Tests\Feature\HasPhotoUploads;
+use Tests\TestCase;
+
+class UploadPhotoWithTagsTest extends TestCase
+{
+    use HasPhotoUploads;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setImagePath();
+    }
+
+    public function test_an_api_user_can_upload_a_photo_with_tags()
+    {
+        Storage::fake('s3');
+        Storage::fake('bbox');
+
+        Event::fake([ImageUploaded::class, IncrementPhotoMonth::class]);
+
+        Carbon::setTestNow();
+
+        $user = User::factory()->create([
+            'active_team' => Team::factory()
+        ]);
+
+        $this->actingAs($user, 'api');
+
+        $imageAttributes = $this->getImageAndAttributes();
+
+        $response = $this->post('/api/photos/submit-with-tags',
+            array_merge(
+                $this->getApiImageAttributes($imageAttributes),
+                ['tags' => ['smoking' => ['butts' => 3]]]
+            )
+        );
+
+        $response->assertOk()->assertJson(['success' => true]);
+
+        $user->refresh();
+        $photo = $user->photos->last();
+
+        // Image is uploaded and tags are correct
+        Storage::disk('s3')->assertExists($imageAttributes['filepath']);
+        Storage::disk('bbox')->assertExists($imageAttributes['filepath']);
+        $this->assertCount(1, $user->photos);
+        $this->assertEquals($imageAttributes['imageName'], $photo->filename);
+        $this->assertEquals($imageAttributes['dateTime'], $photo->datetime);
+        $this->assertNotNull($photo->smoking_id);
+        $this->assertInstanceOf(Smoking::class, $photo->smoking);
+        $this->assertEquals(3, $photo->smoking->butts);
+
+        Event::assertDispatched(ImageUploaded::class);
+        Event::assertDispatched(IncrementPhotoMonth::class);
+    }
+
+    public function validationDataProvider(): array
+    {
+        return [
+            [
+                'fields' => [],
+                'errors' => ['photo', 'lat', 'lon', 'date', 'tags'],
+            ],
+            [
+                'fields' => ['photo' => UploadedFile::fake()->image('some.pdf'), 'lat' => 5, 'lon' => 5, 'date' => now()->toDateTimeString(), 'tags' => ['smoking' => ['butts' => 3]]],
+                'errors' => ['photo']
+            ],
+            [
+                'fields' => ['photo' => 'validImage', 'lat' => 'asdf', 'lon' => 'asdf', 'date' => now()->toDateTimeString(), 'tags' => ['smoking' => ['butts' => 3]]],
+                'errors' => ['lat', 'lon']
+            ],
+            [
+                'fields' => ['photo' => 'validImage', 'lat' => 5, 'lon' => 5, 'date' => now()->toDateTimeString(), 'tags' => 'test'],
+                'errors' => ['tags']
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider validationDataProvider
+     */
+    public function test_the_uploaded_photo_and_tags_are_validated($fields, $errors)
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user, 'api');
+
+        if (($fields['photo'] ?? null) == 'validImage') {
+            $fields['photo'] = $this->getApiImageAttributes($this->getImageAndAttributes());
+        }
+
+        $this->postJson('/api/photos/submit-with-tags', $fields)
+            ->assertStatus(422)
+            ->assertJsonValidationErrors($errors);
+    }
+}


### PR DESCRIPTION
The new api route is `/api/photos/submit-with-tags`.
It accepts the same parameters as API photo upload, with one new parameter called `tags`, which is identical to the 'litter' parameter on the API to add tags.
It returns `['success' => false, 'msg' => 'error-3']` for uploads with incomplete files, or simple validation errors identical to photo upload API. If the request is successful it returns `['success' => true, 'photo_id' => $photo->id]`.