### PR TITLE
Bugfix - HEIC Images

### DIFF
--- a/app/Actions/Photos/MakeImageAction.php
+++ b/app/Actions/Photos/MakeImageAction.php
@@ -48,16 +48,21 @@ class MakeImageAction
             return compact('image', 'exif');
         }
 
+        // Generating a random filename, and not using the image's
+        // original filename to handle cases
+        // that contain spaces or other weird characters
+        $randomFilename = bin2hex(random_bytes(8));
+
         // Path for a temporary file from the upload -> storage/app/heic_images/sample1.heic
         $tmpFilepath = storage_path(
             self::TEMP_HEIC_STORAGE_DIR .
-            $file->getClientOriginalName()
+            $randomFilename . $extension
         );
 
         // Path for a converted temporary file -> storage/app/heic_images/sample1.jpg
         $convertedFilepath = storage_path(
             self::TEMP_HEIC_STORAGE_DIR .
-            str_replace(".$extension", '.jpg', $file->getClientOriginalName())
+            $randomFilename . 'jpg'
         );
 
         // Store the uploaded file on the server

--- a/app/Actions/Photos/MakeImageAction.php
+++ b/app/Actions/Photos/MakeImageAction.php
@@ -3,6 +3,7 @@
 namespace App\Actions\Photos;
 
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\File;
 use Intervention\Image\Facades\Image;
 
 class MakeImageAction
@@ -15,18 +16,53 @@ class MakeImageAction
      *
      * @return \Intervention\Image\Image
      */
-    public function run (UploadedFile $file, bool $resize = false): \Intervention\Image\Image
+    public function run(UploadedFile $file, bool $resize = false): \Intervention\Image\Image
     {
-        $image = Image::make($file);
+        $image = $this->getImage($file);
 
-        if ($resize)
-        {
+        if ($resize) {
             $image->resize(500, 500);
 
             $image->resize(500, 500, function ($constraint) {
                 $constraint->aspectRatio();
             });
         }
+
+        return $image;
+    }
+
+    /**
+     * @param UploadedFile $file
+     * @return \Intervention\Image\Image
+     */
+    protected function getImage(UploadedFile $file): \Intervention\Image\Image
+    {
+        $extension = $file->getClientOriginalExtension();
+
+        if (!in_array($extension, ['heif', 'heic'])) {
+            return Image::make($file);
+        }
+
+        // Path for a temporary file from the upload -> storage/app/sample1.heic
+        $tmpFilepath = storage_path('app/' . $file->getClientOriginalName());
+        // Path for a converted temporary file -> storage/app/sample1.jpg
+        $convertedFilepath = storage_path('app/' . str_replace(".$extension", '.jpg', $file->getClientOriginalName()));
+
+        // Store the uploaded file on the server
+        File::put($tmpFilepath, $file->getContent());
+
+        // Run a shell command to execute ImageMagick conversion
+        exec('magick convert ' . $tmpFilepath . ' ' . $convertedFilepath);
+
+        // Run another shell command to copy the exif data
+        exec('exiftool -overwrite_original_in_place -tagsFromFile ' . $tmpFilepath . ' ' . $convertedFilepath);
+
+        // Make the image from the new converted file
+        $image = Image::make($convertedFilepath);
+
+        // Remove the temporary files from storage
+        unlink($tmpFilepath);
+        unlink($convertedFilepath);
 
         return $image;
     }

--- a/app/Actions/Photos/MakeImageAction.php
+++ b/app/Actions/Photos/MakeImageAction.php
@@ -56,13 +56,13 @@ class MakeImageAction
         // Path for a temporary file from the upload -> storage/app/heic_images/sample1.heic
         $tmpFilepath = storage_path(
             self::TEMP_HEIC_STORAGE_DIR .
-            $randomFilename . $extension
+            $randomFilename . ".$extension"
         );
 
         // Path for a converted temporary file -> storage/app/heic_images/sample1.jpg
         $convertedFilepath = storage_path(
             self::TEMP_HEIC_STORAGE_DIR .
-            $randomFilename . 'jpg'
+            $randomFilename . '.jpg'
         );
 
         // Store the uploaded file on the server

--- a/app/Http/Controllers/ApiPhotosController.php
+++ b/app/Http/Controllers/ApiPhotosController.php
@@ -120,7 +120,7 @@ class ApiPhotosController extends Controller
             ? $request->model
             : 'Mobile app v2';
 
-        $image = $this->makeImageAction->run($file);
+        $image = $this->makeImageAction->run($file)['image'];
 
         $lat  = $request['lat'];
 		$lon  = $request['lon'];
@@ -134,7 +134,7 @@ class ApiPhotosController extends Controller
         );
 
         $bboxImageName = $this->uploadPhotoAction->run(
-            $this->makeImageAction->run($file, true),
+            $this->makeImageAction->run($file, true)['image'],
             $date,
             $file->hashName(),
             'bbox'

--- a/app/Http/Controllers/ApiPhotosController.php
+++ b/app/Http/Controllers/ApiPhotosController.php
@@ -94,7 +94,7 @@ class ApiPhotosController extends Controller
         \Log::info(['store', $request->all()]);
 
         $request->validate([
-            'photo' => 'required', // mime types temp removed
+            'photo' => 'required|mimes:jpg,png,jpeg,heif,heic',
             'lat' => 'required',
             'lon' => 'required',
             'date' => 'required'

--- a/app/Http/Controllers/PhotosController.php
+++ b/app/Http/Controllers/PhotosController.php
@@ -102,9 +102,9 @@ class PhotosController extends Controller
 
         $file = $request->file('file'); // /tmp/php7S8v..
 
-        $image = $this->makeImageAction->run($file);
-
-        $exif = $image->exif();
+        $imageAndExifData = $this->makeImageAction->run($file);
+        $image = $imageAndExifData['image'];
+        $exif = $imageAndExifData['exif'];
 
         if (is_null($exif))
         {
@@ -164,7 +164,7 @@ class PhotosController extends Controller
         );
 
         $bboxImageName = $this->uploadPhotoAction->run(
-            $this->makeImageAction->run($file, true),
+            $this->makeImageAction->run($file, true)['image'],
             $dateTime,
             $file->hashName(),
             'bbox'

--- a/app/Http/Controllers/PhotosController.php
+++ b/app/Http/Controllers/PhotosController.php
@@ -88,7 +88,7 @@ class PhotosController extends Controller
     public function store (Request $request)
     {
         $request->validate([
-           'file' => 'required'
+           'file' => 'required|mimes:jpg,png,jpeg,heif,heic'
         ]);
 
         $user = Auth::user();


### PR DESCRIPTION
- We need to install ImageMagick with heic support, I followed this post, everything went well: https://eplt.medium.com/5-minutes-to-install-imagemagick-with-heic-support-on-ubuntu-18-04-digitalocean-fe2d09dcef1. I think we only need Step 1. We don't use the Imagick php driver, it failed everytime. To confirm that we have heic support on the production server, we can run `mogrify --version` and we should see 'heic' listed under Delegates.
- We'll also need the `exiftool ` for ubuntu (to copy location tags between images) with: `sudo apt-get update -y && sudo apt-get install -y exiftool`
- Need to create a new folder `storage/app/heic_images/`.

And that's it, it should work fine after that.