### PR TITLE
Bugfixes - Small fixes on Global Map and clustering

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -25,6 +25,7 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule)
     {
         $schedule->command('sitemap:generate')->daily();
+        $schedule->command('clusters:generate-all')->mondays();
     }
 
     /**

--- a/app/Http/Controllers/GlobalMap/GlobalMapController.php
+++ b/app/Http/Controllers/GlobalMap/GlobalMapController.php
@@ -29,6 +29,7 @@ class GlobalMapController extends Controller
             'geohash',
             'lat',
             'lon',
+            'remaining',
             'datetime'
         )
         ->where([
@@ -86,7 +87,8 @@ class GlobalMapController extends Controller
                     'verified' => $photo->verified,
                     'name'     => $showName ? $photo->user->name : null,
                     'username' => $showUsername ? $photo->user->username : null,
-                    'team'     => $teamName ? $teamName : null
+                    'team'     => $teamName ? $teamName : null,
+                    'picked_up'=> $photo->picked_up
                 ]
             ];
 

--- a/app/Http/Controllers/MapController.php
+++ b/app/Http/Controllers/MapController.php
@@ -145,6 +145,7 @@ class MapController extends Controller
 				  'remaining' => $c["remaining"],
 			   'display_name' => $c["display_name"],
 			   'result_string' => $c["result_string"],
+			   'picked_up' => $c->picked_up,
 
 					// data
 					'smoking' => $c->smoking,

--- a/app/Http/Controllers/PhotosController.php
+++ b/app/Http/Controllers/PhotosController.php
@@ -328,7 +328,7 @@ class PhotosController extends Controller
 
         $this->updateLeaderboardsAction->run($user, $photo);
 
-        $photo->remaining = $request->presence;
+        $photo->remaining = !$request->presence;
         $photo->total_litter = $litterTotals['litter'];
 
         if (!$user->is_trusted)

--- a/app/Http/Controllers/Teams/TeamsDataController.php
+++ b/app/Http/Controllers/Teams/TeamsDataController.php
@@ -61,7 +61,8 @@ class TeamsDataController extends Controller
                     'model' => $photo->model,
                     'datetime' => $photo->datetime,
                     'latlng' => [$photo->lat, $photo->lon],
-                    'text' => $photo->result_string
+                    'text' => $photo->result_string,
+                    'picked_up'=> $photo->picked_up
                 ]
             ];
 

--- a/app/Http/Controllers/User/ProfileController.php
+++ b/app/Http/Controllers/User/ProfileController.php
@@ -73,7 +73,7 @@ class ProfileController extends Controller
 //        else if (request()->period === 'all') $period = '2017-01-01 00:00:00'; // Year OLM began
 
         // Todo - Pre-cluster each users photos
-        $query = Photo::select('id', 'filename', 'datetime', 'lat', 'lon', 'model', 'result_string', 'created_at')
+        $query = Photo::select('id', 'filename', 'datetime', 'lat', 'lon', 'model', 'result_string', 'remaining', 'created_at')
             ->where([
                 ['user_id', auth()->user()->id],
                 'verified' => 2
@@ -109,7 +109,8 @@ class ProfileController extends Controller
                     'model' => $photo->model,
                     'datetime' => $photo->datetime,
                     'latlng' => [$photo->lat, $photo->lon],
-                    'text' => $photo->result_string
+                    'text' => $photo->result_string,
+                    'picked_up' => $photo->picked_up
                 ]
             ];
 

--- a/app/Models/Litter/LitterCategory.php
+++ b/app/Models/Litter/LitterCategory.php
@@ -43,7 +43,9 @@ abstract class LitterCategory extends Model
         {
             if ($this->$type)
             {
-                $string .= $this->table . '.' . $type . ' ' . $this->$type . ',';
+                $className = $this->table == 'arts' ? 'art' : $this->table;
+
+                $string .= $className . '.' . $type . ' ' . $this->$type . ',';
             }
         }
 

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js",
-    "/css/app.css": "/css/app.css"
+    "/js/app.js": "/js/app.js?id=edc79be9b10526691dc8",
+    "/css/app.css": "/css/app.css?id=d41d8cd98f00b204e980"
 }

--- a/resources/js/components/Profile/middle/ProfileMap.vue
+++ b/resources/js/components/Profile/middle/ProfileMap.vue
@@ -79,6 +79,7 @@ export default {
                 feature.properties.img,
                 feature.properties.text,
                 feature.properties.datetime,
+                feature.properties.picked_up,
                 '',
                 ''
             );

--- a/resources/js/components/Teams/TeamMap.vue
+++ b/resources/js/components/Teams/TeamMap.vue
@@ -75,6 +75,7 @@ export default {
                 feature.properties.img,
                 feature.properties.text,
                 feature.properties.datetime,
+                feature.properties.picked_up,
                 '',
                 ''
             );

--- a/resources/js/maps/mapHelpers.js
+++ b/resources/js/maps/mapHelpers.js
@@ -52,6 +52,18 @@ const helper = {
     },
 
     /**
+     * Formats the picked up text for usage in Photo popups
+     *
+     * @returns {string}
+     * @param pickedUp
+     */
+    formatPickedUp: (pickedUp) => {
+        return pickedUp
+            ? `${i18n.t('litter.presence.picked-up')}`
+            : `${i18n.t('litter.presence.still-there')}`;
+    },
+
+    /**
      * Formats the team name for usage in Photo popups
      *
      * Todo translate 'team'
@@ -80,14 +92,16 @@ const helper = {
      * @param imageUrl
      * @param tagsString
      * @param takenOn
+     * @param pickedUp
      * @param user
      * @param team
      * @returns {string}
      */
-    getMapImagePopupContent: (imageUrl, tagsString, takenOn, user, team) => {
+    getMapImagePopupContent: (imageUrl, tagsString, takenOn, pickedUp, user, team) => {
         const tags = helper.parseTags(tagsString);
         const takenDateString = helper.formatPhotoTakenTime(takenOn);
         const teamFormatted = helper.formatTeam(team);
+        const pickedUpFormatted = helper.formatPickedUp(pickedUp);
 
         return `
             <img
@@ -98,6 +112,7 @@ const helper = {
             />
             <div class="leaflet-litter-img-container">
                 <p>${tags}</p>
+                <p>${pickedUpFormatted}</p>
                 <p>${takenDateString}</p>
                 ${user || teamFormatted ? ('<p>' + user + '<br>' + teamFormatted + '</p>') : ''}
             </div>`;

--- a/resources/js/views/Locations/CityMap.vue
+++ b/resources/js/views/Locations/CityMap.vue
@@ -333,6 +333,7 @@ export default {
                                     i.properties.filename,
                                     i.properties.result_string,
                                     i.properties.datetime,
+                                    i.properties.picked_up,
                                     mapHelper.formatUserName(name, username),
                                     i.properties.team
                                 ),

--- a/resources/js/views/global/Supercluster.vue
+++ b/resources/js/views/global/Supercluster.vue
@@ -190,6 +190,7 @@ function onEachArtFeature (feature, layer)
                     feature.properties.filename,
                     null,
                     feature.properties.datetime,
+                    feature.properties.picked_up,
                     user,
                     feature.properties.team
                 )
@@ -402,6 +403,7 @@ export default {
                         feature.properties.filename,
                         feature.properties.result_string,
                         feature.properties.datetime,
+                        feature.properties.picked_up,
                         user,
                         feature.properties.team
                     )

--- a/tests/Feature/Admin/UpdateTagsDeletePhotoTest.php
+++ b/tests/Feature/Admin/UpdateTagsDeletePhotoTest.php
@@ -142,7 +142,7 @@ class UpdateTagsDeletePhotoTest extends TestCase
         $this->assertEquals(11, $this->user->xp); // 1 xp from uploading, + 10xp from alcohol
 
         $this->assertEquals(10, $this->photo->total_litter);
-        $this->assertEquals(1, $this->photo->remaining);
+        $this->assertEquals(0, $this->photo->remaining);
         $this->assertEquals(1, $this->photo->verification);
         $this->assertEquals(2, $this->photo->verified);
     }

--- a/tests/Feature/Photos/AddTagsToPhotoTest.php
+++ b/tests/Feature/Photos/AddTagsToPhotoTest.php
@@ -60,7 +60,7 @@ class AddTagsToPhotoTest extends TestCase
         // Assert tags are stored correctly ------------
         $photo->refresh();
 
-        $this->assertEquals(1, $photo->remaining);
+        $this->assertEquals(0, $photo->remaining);
         $this->assertNotNull($photo->smoking_id);
         $this->assertInstanceOf(Smoking::class, $photo->smoking);
         $this->assertEquals(3, $photo->smoking->butts);
@@ -101,7 +101,7 @@ class AddTagsToPhotoTest extends TestCase
 
         $this->assertEquals(9, $user->xp); // 1 xp from uploading, + 8xp from total litter tagged
         $this->assertEquals(8, $photo->total_litter);
-        $this->assertEquals(0, $photo->remaining);
+        $this->assertEquals(1, $photo->remaining);
         $this->assertEquals(0.1, $photo->verification);
     }
 

--- a/tests/Unit/Models/Litter/LitterCategoryTest.php
+++ b/tests/Unit/Models/Litter/LitterCategoryTest.php
@@ -64,7 +64,8 @@ class LitterCategoryTest extends TestCase
 
         $expected = '';
         foreach ($types as $type) {
-            $expected .= $model->getTable() . '.' . $type . ' ' . $model->$type . ',';
+            $className = $model->getTable() == 'arts' ? 'art' : $model->getTable();
+            $expected .= $className . '.' . $type . ' ' . $model->$type . ',';
         }
 
         $this->assertEquals($expected, $model->translate());


### PR DESCRIPTION
https://trello.com/c/gZ2sSaeP

This PR improves the clustering command:
- Refactoring for more readability
- Use `cursor` instead of `get` to keep the memory consumption low during features generation
- Use Laravel progress bars and console output helpers
- Use batch insert statements instead of single insert per cluster during clusters generation

Clustering is improved at about 3x the speed of the previous version, and there are no memory errors, regardless of total number of photos.

- Schedules the Clustering command to be executed on Sunday at midnight (or Monday at 00:00)
- Added Picked Up status to every photo popup on the global map, teams, profile, and cities maps. Text is translated and is the same as shown on the Tagging page.
- Fixes translation error on Art litter popups, we were using 'arts' as the translation key, but it was 'art' on the translation json. Switched to using 'art' instead.

We need to set the correct .env variable on each server:
`APP_ROOT_DIR=/home/vagrant/code/olm` on local envs,
`APP_ROOT_DIR=/home/forge/olmdev.online` on staging,
`APP_ROOT_DIR=/home/forge/openlittermap.com` on the production server