### PR TITLE
Bugfix - Teams map

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,6 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=http://olm.test
-APP_ROOT_DIR=/home/vagrant/Code/olm
 
 LOG_CHANNEL=stack
 

--- a/app/Console/Commands/Clusters/GenerateClusters.php
+++ b/app/Console/Commands/Clusters/GenerateClusters.php
@@ -99,7 +99,7 @@ class GenerateClusters extends Command
         foreach ($zoomLevels as $zoomLevel) {
             $this->line("Zoom level " . $zoomLevel);
 
-            exec('node app/Node/supercluster-php ' . config('app.root_dir') . ' ' . $zoomLevel);
+            exec('node app/Node/supercluster-php ' . base_path() . ' ' . $zoomLevel);
 
             collect(json_decode(Storage::get('/data/clusters.json')))
                 ->filter(function ($cluster) {

--- a/app/Console/Commands/Clusters/GenerateClusters.php
+++ b/app/Console/Commands/Clusters/GenerateClusters.php
@@ -25,16 +25,6 @@ class GenerateClusters extends Command
     protected $description = 'Generate all clusters for all photos';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Generate Clusters for All Photos
      *
      * Todo - Load photos as geojson without looping over them and inserting into another array
@@ -84,7 +74,7 @@ class GenerateClusters extends Command
                 ]
             ];
 
-            array_push($features, $feature);
+            $features[] = $feature;
 
             $bar->advance();
         }

--- a/app/Console/Commands/Clusters/GenerateTeamClusters.php
+++ b/app/Console/Commands/Clusters/GenerateTeamClusters.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace App\Console\Commands\Clusters;
+
+use App\Models\Photo;
+use App\Models\TeamCluster;
+use App\Models\Teams\Team;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+class GenerateTeamClusters extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'clusters:generate-team-clusters';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate all clusters for teams photos';
+
+    private $clustersDir = 'team-clusters.json';
+    private $featuresDir = 'team-features.json';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $start = microtime(true);
+
+        $teamsWithImages = Team::where('total_images', '>', 0)->get();
+
+        foreach ($teamsWithImages as $team) {
+            $this->line("\n\n<info>Team:</info> $team->name");
+
+            $this->generateFeatures($team);
+            $this->deleteClusters($team);
+            $this->generateClusters($team);
+        }
+
+        $finish = microtime(true);
+        $this->newLine();
+        $this->info("Total Time: " . ($finish - $start) . "\n");
+
+        return 0;
+    }
+
+    /**
+     * Generates features.json
+     */
+    protected function generateFeatures(Team $team): void
+    {
+        $this->info("Generating features...");
+
+        $bar = $this->output->createProgressBar(
+            Photo::whereTeamId($team->id)->count()
+        );
+        $bar->setFormat('debug');
+        $bar->start();
+
+        $photos = Photo::query()
+            ->select('lat', 'lon')
+            ->whereTeamId($team->id)
+            ->cursor();
+
+        $features = [];
+
+        foreach ($photos as $photo) {
+            $feature = [
+                'type' => 'Feature',
+                'geometry' => [
+                    'type' => 'Point',
+                    'coordinates' => [$photo->lon, $photo->lat]
+                ]
+            ];
+
+            $features[] = $feature;
+
+            $bar->advance();
+        }
+
+        $bar->finish();
+
+        $features = json_encode($features, JSON_NUMERIC_CHECK);
+        Storage::put("/data/$this->featuresDir", $features);
+
+        $this->info("\nFeatures finished...");
+    }
+
+    /**
+     * Generates clusters.json
+     */
+    protected function generateClusters(Team $team): void
+    {
+        $this->info("Generating clusters for each zoom level...");
+
+        $rootDir = config('app.root_dir');
+        $zoomLevels = range(2, 16);
+        $time = now();
+
+        $bar = $this->output->createProgressBar(16);
+        $bar->setFormat('debug');
+        $bar->advance();
+        $bar->start();
+
+        foreach ($zoomLevels as $zoomLevel) {
+            exec("node app/Node/supercluster-php $rootDir $zoomLevel $this->featuresDir $this->clustersDir");
+
+            collect(json_decode(Storage::get("/data/$this->clustersDir")))
+                ->filter(function ($cluster) {
+                    return isset($cluster->properties);
+                })
+                ->map(function ($cluster) use ($team, $zoomLevel, $time) {
+                    return [
+                        'team_id' => $team->id,
+                        'zoom' => $zoomLevel,
+                        'lat' => $cluster->geometry->coordinates[1],
+                        'lon' => $cluster->geometry->coordinates[0],
+                        'point_count' => $cluster->properties->point_count,
+                        'point_count_abbreviated' => $cluster->properties->point_count_abbreviated,
+                        'geohash' => \GeoHash::encode($cluster->geometry->coordinates[1], $cluster->geometry->coordinates[0]),
+                        'created_at' => $time,
+                        'updated_at' => $time,
+                    ];
+                })
+                ->chunk(1000)
+                ->each(function ($chunk) {
+                    TeamCluster::insert($chunk->all());
+                });
+
+            $bar->advance();
+        }
+
+        $bar->finish();
+
+        $this->info("\nClusters finished...");
+    }
+
+    /**
+     * @param Team $team
+     */
+    protected function deleteClusters(Team $team)
+    {
+        $this->info("Deleting clusters...");
+
+        TeamCluster::whereTeamId($team->id)->delete();
+    }
+}

--- a/app/Console/Commands/Clusters/GenerateTeamClusters.php
+++ b/app/Console/Commands/Clusters/GenerateTeamClusters.php
@@ -102,7 +102,7 @@ class GenerateTeamClusters extends Command
     {
         $this->info("Generating clusters for each zoom level...");
 
-        $rootDir = config('app.root_dir');
+        $rootDir = base_path();
         $zoomLevels = range(2, 16);
         $time = now();
 

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -25,8 +25,8 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule)
     {
         $schedule->command('sitemap:generate')->daily();
-        $schedule->command('clusters:generate-all')->mondays();
-        $schedule->command('clusters:generate-team-clusters')->weeklyOn(Schedule::MONDAY, '0:20');
+        $schedule->command('clusters:generate-all')->daily();
+        $schedule->command('clusters:generate-team-clusters')->dailyAt('0:10');
     }
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -26,6 +26,7 @@ class Kernel extends ConsoleKernel
     {
         $schedule->command('sitemap:generate')->daily();
         $schedule->command('clusters:generate-all')->mondays();
+        $schedule->command('clusters:generate-team-clusters')->weeklyOn(Schedule::MONDAY, '0:20');
     }
 
     /**

--- a/app/Http/Controllers/GlobalMap/GlobalMapController.php
+++ b/app/Http/Controllers/GlobalMap/GlobalMapController.php
@@ -15,89 +15,35 @@ class GlobalMapController extends Controller
     /**
      * Return the Art data for the global map
      *
+     * @param Request $request
      * @return array points
      */
-    public function artData () :array
+    public function artData(Request $request): array
     {
-        $photos = Photo::select(
-            'id',
-            'verified',
-            'user_id',
-            'team_id',
-            'result_string',
-            'filename',
-            'geohash',
-            'lat',
-            'lon',
-            'remaining',
-            'datetime'
-        )
-        ->where([
-            ['verified', '>=', 2],
-            ['art_id', '!=', null]
-        ])->get();
+        $query = Photo::query()
+            ->select(
+                'id',
+                'verified',
+                'user_id',
+                'team_id',
+                'result_string',
+                'filename',
+                'geohash',
+                'lat',
+                'lon',
+                'remaining',
+                'datetime'
+            )
+            ->where([
+                ['verified', '>=', 2],
+                ['art_id', '!=', null]
+            ]);
 
-        return $this->photosToGeojson($photos);
-    }
-
-    /**
-     * Convert our photos object to a geojson array
-     *
-     * @param $photos
-     *
-     * @return array
-     */
-    protected function photosToGeojson ($photos) :array
-    {
-        $geojson = [
-            'type'      => 'FeatureCollection',
-            'features'  => null
-        ];
-
-        $features = [];
-
-        // Loop over all clusters and add each feature to the features array
-        // Todo - Remove duplication as 1 user may have uploaded many photos
-        foreach ($photos as $photo)
-        {
-            $showName = $showUsername = $teamName = false;
-
-            if ($photo->user)
-            {
-                $showName = $photo->user->show_name_maps;
-                $showUsername = $photo->user->show_username_maps;
-            }
-
-            if ($photo->team)
-            {
-                $teamName = $photo->team->name;
-            }
-
-            $feature = [
-                'type' => 'Feature',
-                'geometry' => [
-                    'type' => 'Point',
-                    'coordinates' => [$photo->lat, $photo->lon]
-                ],
-                'properties' => [
-                    'result_string' => $photo->verified >= 2 ? $photo->result_string : null,
-                    'filename' => $photo->verified >= 2 ? $photo->filename : '/assets/images/waiting.png',
-                    'datetime' => $photo->datetime,
-                    'cluster'  => false,
-                    'verified' => $photo->verified,
-                    'name'     => $showName ? $photo->user->name : null,
-                    'username' => $showUsername ? $photo->user->username : null,
-                    'team'     => $teamName ? $teamName : null,
-                    'picked_up'=> $photo->picked_up
-                ]
-            ];
-
-            array_push($features, $feature);
+        if ($request->team) {
+            $query->whereTeamId($request->team);
         }
 
-        $geojson['features'] = $features;
-
-        return $geojson;
+        return $this->photosToGeojson($query->get());
     }
 
     /**
@@ -105,10 +51,34 @@ class GlobalMapController extends Controller
      *
      * @return array
      */
-    public function index (): array
+    public function index(): array
     {
+        $query = Photo::query()
+            ->select(
+                'id',
+                'verified',
+                'user_id',
+                'team_id',
+                'result_string',
+                'filename',
+                'geohash',
+                'lat',
+                'lon',
+                'datetime'
+            )
+            ->with([
+                'user' => function ($query) {
+                    $query->where('users.show_name_maps', 1)
+                        ->orWhere('users.show_username_maps', 1)
+                        ->select('users.id', 'users.name', 'users.username', 'users.show_username_maps', 'users.show_name_maps');
+                },
+                'team' => function ($query) {
+                    $query->select('teams.id', 'teams.name');
+                }
+            ]);
+
         $photos = $this->filterPhotosByGeoHash(
-            request()->zoom,
+            $query,
             request()->bbox,
             request()->layers ?: null
         )->get();

--- a/app/Http/Controllers/GlobalMap/GlobalMapController.php
+++ b/app/Http/Controllers/GlobalMap/GlobalMapController.php
@@ -15,12 +15,11 @@ class GlobalMapController extends Controller
     /**
      * Return the Art data for the global map
      *
-     * @param Request $request
      * @return array points
      */
-    public function artData(Request $request): array
+    public function artData(): array
     {
-        $query = Photo::query()
+        $photos = Photo::query()
             ->select(
                 'id',
                 'verified',
@@ -37,13 +36,10 @@ class GlobalMapController extends Controller
             ->where([
                 ['verified', '>=', 2],
                 ['art_id', '!=', null]
-            ]);
+            ])
+            ->get();
 
-        if ($request->team) {
-            $query->whereTeamId($request->team);
-        }
-
-        return $this->photosToGeojson($query->get());
+        return $this->photosToGeojson($photos);
     }
 
     /**

--- a/app/Http/Controllers/Teams/TeamsClusterController.php
+++ b/app/Http/Controllers/Teams/TeamsClusterController.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Http\Controllers\Teams;
+
+use App\Models\Cluster;
+use App\Models\Photo;
+use App\Traits\FilterClustersByGeohashTrait;
+
+use App\Http\Controllers\Controller;
+use App\Traits\FilterPhotosByGeoHashTrait;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\Request;
+
+class TeamsClusterController extends Controller
+{
+    use FilterClustersByGeohashTrait;
+    use FilterPhotosByGeoHashTrait;
+
+    /**
+     * Get clusters for the teams map
+     *
+     * @param Request $request
+     * @return array
+     */
+    public function clusters(Request $request): array
+    {
+        if (!$request->team) {
+            return [
+                'type' => 'FeatureCollection',
+                'features' => []
+            ];
+        }
+
+        $clusters = $this->getClusters($request->team);
+
+        $features = $this->getFeatures($clusters);
+
+        return [
+            'type' => 'FeatureCollection',
+            'features' => $features
+        ];
+    }
+
+    /**
+     * Get photos point data at zoom levels 16 or above
+     *
+     * @param Request $request
+     * @return array
+     */
+    public function points(Request $request): array
+    {
+        $query = Photo::query()
+            ->select(
+                'id',
+                'verified',
+                'user_id',
+                'team_id',
+                'result_string',
+                'filename',
+                'geohash',
+                'lat',
+                'lon',
+                'datetime'
+            )
+            ->with([
+                'user' => function ($query) {
+                    $query->where('users.show_name_maps', 1)
+                        ->orWhere('users.show_username_maps', 1)
+                        ->select('users.id', 'users.name', 'users.username', 'users.show_username_maps', 'users.show_name_maps');
+                },
+                'team' => function ($query) {
+                    $query->select('teams.id', 'teams.name');
+                }
+            ])
+            ->whereTeamId($request->team);
+
+        $photos = $this->filterPhotosByGeoHash(
+            $query,
+            $request->bbox,
+            $request->layers ?: null
+        )->get();
+
+        return $this->photosToGeojson($photos);
+    }
+
+    /**
+     * @return Builder[]|Collection
+     */
+    protected function getClusters($teamId)
+    {
+        // TODO replace with teams clusters TeamCluster
+        $query = Cluster::query();
+
+        // If the zoom is 2,3,4,5 -> get all clusters for this zoom level
+        if (request()->zoom <= 5) {
+            return $query->where('zoom', request()->zoom)->get();
+        }
+
+        return $this->filterClustersByGeoHash(
+            $query,
+            request()->zoom,
+            request()->bbox
+        )->get();
+    }
+}

--- a/app/Http/Controllers/Teams/TeamsClusterController.php
+++ b/app/Http/Controllers/Teams/TeamsClusterController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers\Teams;
 
-use App\Models\Cluster;
 use App\Models\Photo;
+use App\Models\TeamCluster;
 use App\Traits\FilterClustersByGeohashTrait;
 
 use App\Http\Controllers\Controller;
@@ -89,8 +89,7 @@ class TeamsClusterController extends Controller
      */
     protected function getClusters($teamId)
     {
-        // TODO replace with teams clusters TeamCluster
-        $query = Cluster::query();
+        $query = TeamCluster::query()->whereTeamId($teamId);
 
         // If the zoom is 2,3,4,5 -> get all clusters for this zoom level
         if (request()->zoom <= 5) {

--- a/app/Http/Controllers/Teams/TeamsDataController.php
+++ b/app/Http/Controllers/Teams/TeamsDataController.php
@@ -38,42 +38,10 @@ class TeamsDataController extends Controller
             ->where('verified', 2)
             ->sum('total_litter');
 
-        $geojson = [
-            'type' => 'FeatureCollection',
-            'features' => []
-        ];
-
-        $photos = $query->get();
-
-        // Populate geojson object
-        foreach ($photos as $photo)
-        {
-            $feature = [
-                'type' => 'Feature',
-                'geometry' => [
-                    'type' => 'Point',
-                    'coordinates' => [$photo->lon, $photo->lat]
-                ],
-
-                'properties' => [
-                    'photo_id' => $photo->id,
-                    'img' => $photo->filename,
-                    'model' => $photo->model,
-                    'datetime' => $photo->datetime,
-                    'latlng' => [$photo->lat, $photo->lon],
-                    'text' => $photo->result_string,
-                    'picked_up'=> $photo->picked_up
-                ]
-            ];
-
-            array_push($geojson["features"], $feature);
-        }
-
         return [
             'photos_count' => $photosCount,
             'litter_count' => $litterCount,
-            'members_count' => $membersCount,
-            'geojson' => $geojson
+            'members_count' => $membersCount
         ];
     }
 

--- a/app/Models/TeamCluster.php
+++ b/app/Models/TeamCluster.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TeamCluster extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+}

--- a/app/Node/supercluster-php/index.js
+++ b/app/Node/supercluster-php/index.js
@@ -2,13 +2,15 @@ let Supercluster = require('supercluster');
 
 const fs = require('fs');
 const prefix = process.argv.slice(2)[0]; // '/home/forge/openlittermap.com'; or '/home/vagrant/Code/olm';
-const x = '/storage/app/data/features.json';
-const file = prefix + x;
-
 const zoom = process.argv.slice(3)[0];
+const featuresFilename = process.argv.slice(4)[0] || 'features.json';
+const clustersFilename = process.argv.slice(5)[0] || 'clusters.json';
+const storagePath = '/storage/app/data/';
 
-let rawdata = fs.readFileSync(file);
-let features = JSON.parse(rawdata);
+const file = prefix + storagePath + featuresFilename;
+
+let rawData = fs.readFileSync(file);
+let features = JSON.parse(rawData);
 
 let index = new Supercluster({
     log: true,
@@ -21,6 +23,6 @@ index.load(features);
 const bbox = [-180, -85, 180, 85];
 let clusters = index.getClusters(bbox, zoom);
 
-fs.writeFile(prefix + '/storage/app/data/clusters.json', JSON.stringify(clusters), function (err, data) {
+fs.writeFile(prefix + storagePath + clustersFilename, JSON.stringify(clusters), function (err, data) {
     if (err) return console.log(err);
 });

--- a/app/Traits/FilterClustersByGeohashTrait.php
+++ b/app/Traits/FilterClustersByGeohashTrait.php
@@ -31,7 +31,7 @@ trait FilterClustersByGeohashTrait
         $precision = $this->getGeohashPrecision($zoom);
 
         // Get the center of the bounding box, as a geohash
-        $center_geohash = GeoHash::encode($center_lat, $center_lon, $precision); // precision 0 will return the full geohash
+        $center_geohash = \GeoHash::encode($center_lat, $center_lon, $precision); // precision 0 will return the full geohash
 
         // get the neighbour geohashes from our center geohash
         $geos = array_values($this->neighbors($center_geohash));

--- a/app/Traits/FilterClustersByGeohashTrait.php
+++ b/app/Traits/FilterClustersByGeohashTrait.php
@@ -2,9 +2,8 @@
 
 namespace App\Traits;
 
-use GeoHash;
-use App\Models\Cluster;
-use App\Traits\GeohashTrait;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 
 trait FilterClustersByGeohashTrait
 {
@@ -15,10 +14,12 @@ trait FilterClustersByGeohashTrait
      *
      * For a specific zoom level, we want to return the bounding box of the clusters + neighbours
      *
+     * @param Builder $query
      * @param $zoom int   -> zoom level of the browser
      * @param $bbox array -> [west|left, south|bottom, east|right, north|top]
+     * @return Builder
      */
-    public function filterClustersByGeoHash (int $zoom, string $bbox)
+    public function filterClustersByGeoHash (Builder $query, int $zoom, string $bbox): Builder
     {
         $bbox = json_decode($bbox);
 
@@ -27,30 +28,42 @@ trait FilterClustersByGeohashTrait
         $center_lon = ($bbox->left + $bbox->right) / 2;
 
         // zoom level will determine what level of geohash precision to use
-        $precision = $this->getGeohashPrecision(request()->zoom);
+        $precision = $this->getGeohashPrecision($zoom);
 
         // Get the center of the bounding box, as a geohash
         $center_geohash = GeoHash::encode($center_lat, $center_lon, $precision); // precision 0 will return the full geohash
 
-        $geos = [];
         // get the neighbour geohashes from our center geohash
-        $ns = $this->neighbors($center_geohash);
-        foreach ($ns as $n) array_push($geos, $n);
+        $geos = array_values($this->neighbors($center_geohash));
 
-        $query = Cluster::query();
+        return $query
+            ->where('zoom', $zoom)
+            ->where(function ($q) use ($geos) {
+                foreach ($geos as $geo) {
+                    $q->orWhere('geohash', 'like', $geo . '%'); // starts with
+                }
+            });
+    }
 
-        // Build cluster query
-        $query->where(function ($q) use ($geos, $zoom)
-        {
-            foreach ($geos as $geo)
-            {
-                $q->orWhere([
-                    'zoom' => $zoom,
-                    ['geohash', 'like', $geo . '%'] // starts with
-                ]);
-            }
-        });
-
-        return $query;
+    /**
+     * @param Collection $clusters
+     * @return array
+     */
+    protected function getFeatures(Collection $clusters): array
+    {
+        return $clusters->map(function ($cluster) {
+            return [
+                'type' => 'Feature',
+                'geometry' => [
+                    'type' => 'Point',
+                    'coordinates' => [$cluster->lon, $cluster->lat]
+                ],
+                'properties' => [
+                    'point_count' => $cluster->point_count,
+                    'point_count_abbreviated' => $cluster->point_count_abbreviated,
+                    'cluster' => true
+                ]
+            ];
+        })->toArray();
     }
 }

--- a/app/Traits/FilterClustersByGeohashTrait.php
+++ b/app/Traits/FilterClustersByGeohashTrait.php
@@ -46,6 +46,8 @@ trait FilterClustersByGeohashTrait
     }
 
     /**
+     * Converts the clusters into the format required by the map
+     *
      * @param Collection $clusters
      * @return array
      */

--- a/app/Traits/FilterPhotosByGeoHashTrait.php
+++ b/app/Traits/FilterPhotosByGeoHashTrait.php
@@ -31,7 +31,7 @@ trait FilterPhotosByGeoHashTrait
         $precision = $this->getGeohashPrecision(request()->zoom);
 
         // Get the center of the bounding box, as a geohash
-        $center_geohash = GeoHash::encode($center_lat, $center_lon, $precision); // precision 0 will return the full geohash
+        $center_geohash = \GeoHash::encode($center_lat, $center_lon, $precision); // precision 0 will return the full geohash
 
         // get the neighbour geohashes from our center geohash
         $geos = array_values($this->neighbors($center_geohash));

--- a/app/Traits/FilterPhotosByGeoHashTrait.php
+++ b/app/Traits/FilterPhotosByGeoHashTrait.php
@@ -59,7 +59,7 @@ trait FilterPhotosByGeoHashTrait
     }
 
     /**
-     * Convert our photos object to a geojson array
+     * Convert our photos object into a geojson array
      *
      * @param $photos
      *

--- a/app/Traits/GeohashTrait.php
+++ b/app/Traits/GeohashTrait.php
@@ -86,8 +86,6 @@ trait GeohashTrait
      */
     public function neighbors ($srcHash)
     {
-        $geohashPrefix = substr($srcHash, 0, strlen($srcHash) - 1);
-
         $neighbors['top'] = $this->calculateAdjacent($srcHash, 'top');
         $neighbors['bottom'] = $this->calculateAdjacent($srcHash, 'bottom');
         $neighbors['right'] = $this->calculateAdjacent($srcHash, 'right');

--- a/config/app.php
+++ b/config/app.php
@@ -123,8 +123,6 @@ return [
 
     'cipher' => 'AES-256-CBC',
 
-    'root_dir' => env('APP_ROOT_DIR', '/home/forge/openlittermap.com'),
-
     /*
     |--------------------------------------------------------------------------
     | Autoloaded Service Providers

--- a/database/factories/ClusterFactory.php
+++ b/database/factories/ClusterFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Cluster;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ClusterFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Cluster::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition(): array
+    {
+        $pointCount = $this->faker->randomDigitNotNull;
+        return [
+            'lat' => $this->faker->latitude,
+            'lon' => $this->faker->longitude,
+            'point_count' => $pointCount * 1000,
+            'point_count_abbreviated' => "{$pointCount}k",
+            'geohash' => 'gcpvn219nm0ughyj8uemwkpb',
+            'zoom' => $this->faker->randomElement(range(6, 18))
+        ];
+    }
+}

--- a/database/factories/PhotoFactory.php
+++ b/database/factories/PhotoFactory.php
@@ -26,7 +26,9 @@ class PhotoFactory extends Factory
             'user_id' => User::factory()->create(),
             'filename' => $this->faker->name . $this->faker->fileExtension,
             'model' => 'Unknown',
-            'datetime' => $this->faker->dateTime
+            'datetime' => $this->faker->dateTime,
+            'lat' => $this->faker->latitude,
+            'lon' => $this->faker->longitude
         ];
     }
 }

--- a/database/migrations/2021_12_28_174234_create_team_clusters_table.php
+++ b/database/migrations/2021_12_28_174234_create_team_clusters_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTeamClustersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('team_clusters', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('team_id');
+            $table->integer('zoom');
+            $table->double('lat');
+            $table->double('lon');
+            $table->unsignedBigInteger('point_count');
+            $table->string('point_count_abbreviated');
+            $table->string('geohash');
+            $table->timestamps();
+
+            $table->foreign('team_id')
+                ->references('id')
+                ->on('teams');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('team_clusters');
+    }
+}

--- a/resources/js/components/Teams/TeamMap.vue
+++ b/resources/js/components/Teams/TeamMap.vue
@@ -11,7 +11,7 @@
             <button class="btn-map-fullscreen" @click="toggle">
                 <i class="fa fa-expand"/>
             </button>
-            <supercluster
+            <cluster-map
                 :clusters-url="`/teams/clusters/${teamId}`"
                 :points-url="`/teams/points/${teamId}`"
             />
@@ -22,16 +22,16 @@
 <script>
 import Loading from 'vue-loading-overlay';
 import 'vue-loading-overlay/dist/vue-loading.css';
-import Supercluster from '../../views/global/Supercluster';
+import ClusterMap from '../../views/global/ClusterMap';
 
 export default {
     name: 'TeamMap',
     props: ['teamId'],
     components: {
         Loading,
-        Supercluster
+        ClusterMap
     },
-    async created ()
+    async mounted ()
     {
         this.attribution += new Date().getFullYear();
 
@@ -44,9 +44,8 @@ export default {
         },
     },
 
-    // TODO this might not be needed
     watch: {
-        teamId: function() {
+        teamId() {
             this.loadClusters();
         }
     },
@@ -56,9 +55,6 @@ export default {
         {
             await this.$store.dispatch('GET_TEAMS_CLUSTERS', {
                 zoom: 2,
-                team_id: this.teamId
-            });
-            await this.$store.dispatch('GET_TEAMS_ART_DATA', {
                 team_id: this.teamId
             });
 

--- a/resources/js/components/Teams/TeamMap.vue
+++ b/resources/js/components/Teams/TeamMap.vue
@@ -1,9 +1,9 @@
 <template>
     <div class="team-map-container">
-        <loading v-if="loading" :active.sync="loading" :is-full-page="false"/>
+        <loading v-if="loading && teamId > 0" :active.sync="loading" :is-full-page="false"/>
 
         <fullscreen
-            v-else-if="teamId > 0"
+            v-if="teamId > 0"
             ref="fullscreen"
             @change="fullscreenChange"
             class="profile-map-container"
@@ -14,6 +14,7 @@
             <cluster-map
                 :clusters-url="`/teams/clusters/${teamId}`"
                 :points-url="`/teams/points/${teamId}`"
+                @loading-complete="loading = false"
             />
         </fullscreen>
     </div>
@@ -31,36 +32,18 @@ export default {
         Loading,
         ClusterMap
     },
-    async mounted ()
-    {
-        this.attribution += new Date().getFullYear();
-
-        await this.loadClusters();
-    },
-    computed: {
-        loading ()
-        {
-            return this.$store.state.globalmap.loading;
-        },
-    },
-
-    watch: {
-        teamId() {
-            this.loadClusters();
+    data() {
+        return {
+            loading: true
         }
     },
-
-    methods: {
-        async loadClusters ()
+    watch: {
+        teamId (id)
         {
-            await this.$store.dispatch('GET_TEAMS_CLUSTERS', {
-                zoom: 2,
-                team_id: this.teamId
-            });
-
-            this.$store.commit('globalLoading', false);
-        },
-
+            if (id > 0) this.loading = true;
+        }
+    },
+    methods: {
         fullscreenChange (fullscreen)
         {
             this.fullscreen = fullscreen;

--- a/resources/js/store/modules/globalmap/actions.js
+++ b/resources/js/store/modules/globalmap/actions.js
@@ -34,5 +34,42 @@ export const actions = {
         .catch(error => {
             console.error('get_clusters', error);
         });
+    },
+
+    /**
+     * Get clusters for the teams map
+     */
+    async GET_TEAMS_CLUSTERS (context, payload)
+    {
+        await axios.get(`/teams/clusters/${payload.team_id}`, {
+            params: {
+                zoom: payload.zoom,
+                bbox: null
+            }
+        })
+        .then(response => {
+            console.log('get_teams_clusters', response);
+
+            context.commit('updateGlobalData', response.data);
+        })
+        .catch(error => {
+            console.error('get_teams_clusters', error);
+        });
+    },
+
+    /**
+     * Get the art point data for the teams map
+     */
+    async GET_TEAMS_ART_DATA (context, payload)
+    {
+        await axios.get(`/teams/art-data/${payload.team_id}`)
+        .then(response => {
+            console.log('get_teams_art_data', response);
+
+            context.commit('globalArtData', response.data);
+        })
+        .catch(error => {
+            console.error('get_teams_art_data', error);
+        });
     }
 }

--- a/resources/js/store/modules/globalmap/actions.js
+++ b/resources/js/store/modules/globalmap/actions.js
@@ -34,42 +34,5 @@ export const actions = {
         .catch(error => {
             console.error('get_clusters', error);
         });
-    },
-
-    /**
-     * Get clusters for the teams map
-     */
-    async GET_TEAMS_CLUSTERS (context, payload)
-    {
-        await axios.get(`/teams/clusters/${payload.team_id}`, {
-            params: {
-                zoom: payload.zoom,
-                bbox: null
-            }
-        })
-        .then(response => {
-            console.log('get_teams_clusters', response);
-
-            context.commit('updateGlobalData', response.data);
-        })
-        .catch(error => {
-            console.error('get_teams_clusters', error);
-        });
-    },
-
-    /**
-     * Get the art point data for the teams map
-     */
-    async GET_TEAMS_ART_DATA (context, payload)
-    {
-        await axios.get(`/teams/art-data/${payload.team_id}`)
-        .then(response => {
-            console.log('get_teams_art_data', response);
-
-            context.commit('globalArtData', response.data);
-        })
-        .catch(error => {
-            console.error('get_teams_art_data', error);
-        });
     }
 }

--- a/resources/js/views/Teams/TeamsDashboard.vue
+++ b/resources/js/views/Teams/TeamsDashboard.vue
@@ -39,7 +39,7 @@
 
         <p v-if="loading">{{ $t('common.loading') }}</p>
 
-        <TeamMap v-else />
+        <TeamMap v-else :team-id="viewTeam" />
 
     </section>
 </template>

--- a/resources/js/views/Teams/TeamsDashboard.vue
+++ b/resources/js/views/Teams/TeamsDashboard.vue
@@ -37,9 +37,7 @@
             </select>
         </div>
 
-        <p v-if="loading">{{ $t('common.loading') }}</p>
-
-        <TeamMap v-else :team-id="viewTeam" />
+        <TeamMap :team-id="viewTeam" />
 
     </section>
 </template>
@@ -54,11 +52,7 @@ export default {
     },
     async created ()
     {
-        this.loading = true;
-
         await this.changeTeamOrTime();
-
-        this.loading = false;
     },
     data ()
     {
@@ -71,7 +65,6 @@ export default {
                 'year',
                 'all'
             ],
-            loading: true,
             viewTeam: 0
         };
     },

--- a/resources/js/views/global/ClusterMap.vue
+++ b/resources/js/views/global/ClusterMap.vue
@@ -70,20 +70,7 @@ export default {
             onEachFeature: this.onEachFeature,
         }).addTo(this.map);
 
-
-
-        // TODO remove this
-        await this.$store.dispatch('GET_TEAMS_CLUSTERS', {
-            zoom: 2,
-            team_id: 1
-        });
-        console.log(this.$store.state.globalmap.geojson.features)
-
-
-
-
-
-        this.clusters.addData(this.$store.state.globalmap.geojson.features);
+        await this.getClusters(2, null);
 
         this.map.on('moveend', this.update);
         this.map.on('overlayadd', this.update);
@@ -99,6 +86,14 @@ export default {
             iconSize: [13, 10]
         });
     },
+    watch: {
+        clustersUrl()
+        {
+            this.map.setZoom(2);
+
+            this.getClusters(2, null);
+        }
+    },
     methods: {
         async getClusters (zoom, bbox)
         {
@@ -110,15 +105,16 @@ export default {
             })
                 .then(response =>
                 {
-                    console.log('get_clusters.update', response);
+                    console.log('get_map_clusters', response);
 
                     this.clusters.clearLayers();
                     this.clusters.addData(response.data);
                 })
                 .catch(error =>
                 {
-                    console.error('get_clusters.update', error);
-                });
+                    console.error('get_map_clusters', error);
+                })
+                .finally(() => this.$emit('loading-complete'));
         },
 
         async getPoints (zoom, bbox, layers)
@@ -132,7 +128,7 @@ export default {
             })
                 .then(response =>
                 {
-                    console.log('get_global_points', response);
+                    console.log('get_map_points', response);
 
                     // Clear layer if prev layer is cluster.
                     if (this.prevZoom < CLUSTER_ZOOM_THRESHOLD)
@@ -170,7 +166,7 @@ export default {
                 })
                 .catch(error =>
                 {
-                    console.error('get_global_points', error);
+                    console.error('get_map_points', error);
                 });
         },
 

--- a/resources/js/views/global/ClusterMap.vue
+++ b/resources/js/views/global/ClusterMap.vue
@@ -1,0 +1,381 @@
+<template>
+    <div class="h100">
+        <div id="map" ref="map" />
+    </div>
+</template>
+
+<script>
+
+import {
+    CLUSTER_ZOOM_THRESHOLD,
+    MAX_ZOOM,
+    MEDIUM_CLUSTER_SIZE,
+    LARGE_CLUSTER_SIZE,
+    MIN_ZOOM,
+    ZOOM_STEP
+} from '../../constants';
+
+import L from 'leaflet';
+import './SmoothWheelZoom.js';
+
+// Todo - fix this export bug (The request of a dependency is an expression...)
+import glify from 'leaflet.glify';
+import { mapHelper } from '../../maps/mapHelpers';
+
+export default {
+    name: 'ClusterMap',
+    props: ['clustersUrl', 'pointsUrl'],
+    data() {
+        return {
+            map: null,
+            clusters: [],
+            points: [],
+            prevZoom: MIN_ZOOM,
+            pointsLayerController: null,
+            pointsControllerShowing: false,
+            grey_dot: null,
+            green_dot: null
+        }
+    },
+    async mounted ()
+    {
+        /** 1. Create map object */
+        this.map = L.map('map', {
+            center: [0, 0],
+            zoom: MIN_ZOOM,
+            scrollWheelZoom: false,
+            smoothWheelZoom: true,
+            smoothSensitivity: 1,
+        });
+
+        this.map.scrollWheelZoom = true;
+
+        const date = new Date();
+        const year = date.getFullYear();
+
+        /** 2. Add tiles, attribution, set limits */
+        const mapLink = '<a href="https://openstreetmap.org">OpenStreetMap</a>';
+
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: 'Map data &copy; ' + mapLink + ' & Contributors',
+            maxZoom: MAX_ZOOM,
+            minZoom: MIN_ZOOM
+        }).addTo(this.map);
+
+        this.map.attributionControl.addAttribution('Litter data &copy OpenLitterMap & Contributors ' + year + ' Clustering @ MapBox');
+
+        // Empty Layer Group that will receive the clusters data on the fly.
+        this.clusters = L.geoJSON(null, {
+            pointToLayer: this.createClusterIcon,
+            onEachFeature: this.onEachFeature,
+        }).addTo(this.map);
+
+
+
+        // TODO remove this
+        await this.$store.dispatch('GET_TEAMS_CLUSTERS', {
+            zoom: 2,
+            team_id: 1
+        });
+        console.log(this.$store.state.globalmap.geojson.features)
+
+
+
+
+
+        this.clusters.addData(this.$store.state.globalmap.geojson.features);
+
+        this.map.on('moveend', this.update);
+        this.map.on('overlayadd', this.update);
+        this.map.on('overlayremove', this.update);
+
+        this.green_dot = L.icon({
+            iconUrl: './images/vendor/leaflet/dist/dot.png',
+            iconSize: [10, 10]
+        });
+
+        this.grey_dot = L.icon({
+            iconUrl: './images/vendor/leaflet/dist/grey-dot.jpg',
+            iconSize: [13, 10]
+        });
+    },
+    methods: {
+        async getClusters (zoom, bbox)
+        {
+            await axios.get(this.clustersUrl, {
+                params: {
+                    zoom,
+                    bbox
+                }
+            })
+                .then(response =>
+                {
+                    console.log('get_clusters.update', response);
+
+                    this.clusters.clearLayers();
+                    this.clusters.addData(response.data);
+                })
+                .catch(error =>
+                {
+                    console.error('get_clusters.update', error);
+                });
+        },
+
+        async getPoints (zoom, bbox, layers)
+        {
+            await axios.get(this.pointsUrl, {
+                params: {
+                    zoom,
+                    bbox,
+                    layers
+                }
+            })
+                .then(response =>
+                {
+                    console.log('get_global_points', response);
+
+                    // Clear layer if prev layer is cluster.
+                    if (this.prevZoom < CLUSTER_ZOOM_THRESHOLD)
+                    {
+                        this.clusters.clearLayers();
+                    }
+
+                    const data = response.data.features.map(feature =>
+                    {
+                        return [feature.geometry.coordinates[0], feature.geometry.coordinates[1]];
+                    });
+
+                    // New way using webGL
+                    this.points = glify.points({
+                        map: this.map,
+                        data,
+                        size: 10,
+                        color: {r: 0.054, g: 0.819, b: 0.27, a: 1}, // 14, 209, 69 / 255
+                        click: (e, point, xy) =>
+                        {
+                            const feature = response.data.features.find(f =>
+                            {
+                                return f.geometry.coordinates[0] === point[0]
+                                    && f.geometry.coordinates[1] === point[1];
+                            });
+
+                            if (!feature)
+                            {
+                                return;
+                            }
+
+                            return this.renderLeafletPopup(feature, e.latlng)
+                        },
+                    });
+                })
+                .catch(error =>
+                {
+                    console.error('get_global_points', error);
+                });
+        },
+
+        /**
+         * The user dragged or zoomed the map, or changed a category
+         */
+        async update ()
+        {
+            const bounds = this.map.getBounds();
+
+            const bbox = {
+                'left': bounds.getWest(),
+                'bottom': bounds.getSouth(),
+                'right': bounds.getEast(),
+                'top': bounds.getNorth()
+            };
+
+            const zoom = Math.round(this.map.getZoom());
+
+            // We don't want to make a request at zoom level 2-5 if the user is just panning the map.
+            // At these levels, we just load all global data for now
+            if (zoom === 2 && zoom === this.prevZoom) return;
+            if (zoom === 3 && zoom === this.prevZoom) return;
+            if (zoom === 4 && zoom === this.prevZoom) return;
+            if (zoom === 5 && zoom === this.prevZoom) return;
+
+            // Remove points when zooming out
+            if (this.points && this.points.length)
+            {
+                this.clusters.clearLayers();
+                this.points.remove();
+            }
+
+            // Get Clusters or Points
+            if (zoom < CLUSTER_ZOOM_THRESHOLD)
+            {
+                await this.getClusters(zoom, bbox);
+            }
+            else
+            {
+                this.createPointGroups()
+
+                const layers = this.getActiveLayers();
+
+                await this.getPoints(zoom, bbox, layers);
+            }
+
+            this.prevZoom = zoom;
+        },
+
+        /**
+         * Create the cluster or point icon to display for each feature
+         */
+        createClusterIcon (feature, latlng)
+        {
+            if (!feature.properties.cluster)
+            {
+                return (feature.properties.verified === 2)
+                    ? L.marker(latlng, { icon: this.green_dot })
+                    : L.marker(latlng, { icon: this.grey_dot });
+            }
+
+            const count = feature.properties.point_count;
+            const size = (count < MEDIUM_CLUSTER_SIZE)
+                ? 'small'
+                : count < LARGE_CLUSTER_SIZE
+                    ? 'medium'
+                    : 'large';
+
+            const icon = L.divIcon({
+                html: '<div class="mi"><span class="ma">' + feature.properties.point_count_abbreviated + '</span></div>',
+                className: 'marker-cluster-' + size,
+                iconSize: L.point(40, 40)
+            });
+
+            return L.marker(latlng, { icon });
+        },
+
+        /**
+         * Layer Controller when above ZOOM_CLUSTER_THRESHOLD
+         */
+        createPointGroups ()
+        {
+            if (!this.pointsControllerShowing)
+            {
+                const overlays = {
+                    Alcohol: new L.LayerGroup(),
+                    Brands: new L.LayerGroup(),
+                    Coastal: new L.LayerGroup(),
+                    Coffee: new L.LayerGroup(),
+                    Dumping: new L.LayerGroup(),
+                    Food: new L.LayerGroup(),
+                    Industrial: new L.LayerGroup(),
+                    Other: new L.LayerGroup(),
+                    PetSurprise: new L.LayerGroup(),
+                    Sanitary: new L.LayerGroup(),
+                    Smoking: new L.LayerGroup(),
+                    SoftDrinks: new L.LayerGroup(),
+                };
+
+                this.pointsLayerController = L.control.layers(null, overlays).addTo(this.map);
+
+                this.pointsControllerShowing = true;
+            }
+        },
+
+        /**
+         * Zoom to a cluster when it is clicked
+         */
+        onEachFeature (feature, layer)
+        {
+            if (feature.properties.cluster)
+            {
+                const self = this;
+                layer.on('click', function (e)
+                {
+                    const zoomTo = ((self.map.getZoom() + ZOOM_STEP) > MAX_ZOOM)
+                        ? MAX_ZOOM
+                        : (self.map.getZoom() + ZOOM_STEP);
+
+                    self.map.flyTo(e.latlng, zoomTo, {
+                        animate: true,
+                        duration: 2
+                    });
+                });
+            }
+        },
+
+        /**
+         * Get any active layers
+         *
+         * @return layers|null
+         */
+        getActiveLayers ()
+        {
+            let layers = [];
+
+            // This is not ideal but it works as the indexes are in the same order
+            this.pointsLayerController._layerControlInputs.forEach((lyr, index) => {
+                if (lyr.checked)
+                {
+                    // temp fix to rename petsurprise from map to the dogshit table
+                    const name = (this.pointsLayerController._layers[index].name.toLowerCase() === 'petsurprise')
+                        ? 'dogshit'
+                        : this.pointsLayerController._layers[index].name.toLowerCase();
+
+                    layers.push(name);
+                }
+            });
+
+            return (layers.length > 0)
+                ? layers
+                : null;
+        },
+
+        /**
+         * Helper method to create a Popup
+         *
+         * @param feature
+         * @param latLng
+         */
+        renderLeafletPopup (feature, latLng)
+        {
+            const user = mapHelper.formatUserName(feature.properties.name, feature.properties.username);
+
+            L.popup(mapHelper.popupOptions)
+                .setLatLng(latLng)
+                .setContent(
+                    mapHelper.getMapImagePopupContent(
+                        feature.properties.filename,
+                        feature.properties.result_string,
+                        feature.properties.datetime,
+                        feature.properties.picked_up,
+                        user,
+                        feature.properties.team
+                    )
+                )
+                .openOn(this.map);
+        }
+    }
+};
+</script>
+
+<style>
+
+    #map {
+        height: 100%;
+        margin: 0;
+        position: relative;
+    }
+
+    .leaflet-marker-icon {
+        border-radius: 20px;
+    }
+
+    .mi {
+        height: 100%;
+        margin: auto;
+        display: flex;
+        justify-content: center;
+        border-radius: 20px;
+    }
+
+    .leaflet-control {
+        pointer-events: visiblePainted !important;
+    }
+
+</style>

--- a/resources/js/views/global/GlobalMapContainer.vue
+++ b/resources/js/views/global/GlobalMapContainer.vue
@@ -3,7 +3,11 @@
 
         <loading v-if="loading" :active.sync="loading" :is-full-page="true" />
 
-        <supercluster v-else />
+        <supercluster
+            v-else
+            :clusters-url="'/global/clusters'"
+            :points-url="'/global/points'"
+        />
 
     </div>
 </template>

--- a/resources/js/views/global/GlobalMapContainer.vue
+++ b/resources/js/views/global/GlobalMapContainer.vue
@@ -3,11 +3,7 @@
 
         <loading v-if="loading" :active.sync="loading" :is-full-page="true" />
 
-        <supercluster
-            v-else
-            :clusters-url="'/global/clusters'"
-            :points-url="'/global/points'"
-        />
+        <supercluster v-else />
 
     </div>
 </template>

--- a/resources/js/views/global/Supercluster.vue
+++ b/resources/js/views/global/Supercluster.vue
@@ -228,6 +228,7 @@ function getActiveLayers ()
 
 export default {
     name: 'Supercluster',
+    props: ['clustersUrl', 'pointsUrl'],
     components: {
         LiveEvents
     },
@@ -264,6 +265,7 @@ export default {
             onEachFeature: onEachFeature,
         }).addTo(map);
 
+        // TODO refactor this out
         clusters.addData(this.$store.state.globalmap.geojson.features);
 
         litterArtPoints = L.geoJSON(null, {
@@ -271,6 +273,7 @@ export default {
             onEachFeature: onEachArtFeature
         });
 
+        // TODO refactor this out too
         litterArtPoints.addData(this.$store.state.globalmap.artData.features);
 
         map.on('moveend', this.update);
@@ -316,7 +319,7 @@ export default {
             {
                 createGlobalGroups();
 
-                await axios.get('/global/clusters', {
+                await axios.get(this.clustersUrl, {
                     params: {
                         zoom,
                         bbox
@@ -338,7 +341,7 @@ export default {
 
                 const layers = getActiveLayers();
 
-                await axios.get('/global/points', {
+                await axios.get(this.pointsUrl, {
                     params: {
                         zoom,
                         bbox,

--- a/resources/js/views/global/Supercluster.vue
+++ b/resources/js/views/global/Supercluster.vue
@@ -228,7 +228,6 @@ function getActiveLayers ()
 
 export default {
     name: 'Supercluster',
-    props: ['clustersUrl', 'pointsUrl'],
     components: {
         LiveEvents
     },
@@ -319,7 +318,7 @@ export default {
             {
                 createGlobalGroups();
 
-                await axios.get(this.clustersUrl, {
+                await axios.get('/global/clusters', {
                     params: {
                         zoom,
                         bbox
@@ -341,7 +340,7 @@ export default {
 
                 const layers = getActiveLayers();
 
-                await axios.get(this.pointsUrl, {
+                await axios.get('/global/points', {
                     params: {
                         zoom,
                         bbox,

--- a/routes/api.php
+++ b/routes/api.php
@@ -93,11 +93,11 @@ Route::post('/settings/privacy/toggle-previous-tags', 'ApiSettingsController@tog
 
 // Teams
 Route::prefix('/teams')->group(function () {
+    Route::get('/leaderboard', 'Teams\TeamsLeaderboardController@index');
     Route::get('/list', 'API\TeamsController@list');
-    Route::post('/create', 'API\TeamsController@create');
+    Route::get('/types', 'API\TeamsController@types');
     Route::patch('/update/{team}', 'API\TeamsController@update');
+    Route::post('/create', 'API\TeamsController@create');
     Route::post('/join', 'API\TeamsController@join');
     Route::post('/leave', 'API\TeamsController@leave');
-    Route::get('/types', 'API\TeamsController@types');
-    Route::get('/leaderboard', 'Teams\TeamsLeaderboardController@index');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -191,7 +191,6 @@ Route::get('/teams/get-types', 'Teams\TeamsController@types');
 Route::get('/teams/data', 'Teams\TeamsDataController@index');
 Route::get('/teams/clusters/{team}', 'Teams\TeamsClusterController@clusters');
 Route::get('/teams/points/{team}', 'Teams\TeamsClusterController@points');
-Route::get('/teams/art-data/{team}', 'GlobalMap\GlobalMapController@artData');
 
 Route::get('/teams/members', 'Teams\TeamsController@members');
 Route::get('/teams/joined', 'Teams\TeamsController@joined');

--- a/routes/web.php
+++ b/routes/web.php
@@ -189,6 +189,9 @@ Route::post('/settings/save-flag', 'SettingsController@saveFlag');
 Route::get('/teams', 'HomeController@index');
 Route::get('/teams/get-types', 'Teams\TeamsController@types');
 Route::get('/teams/data', 'Teams\TeamsDataController@index');
+Route::get('/teams/clusters/{team}', 'Teams\TeamsClusterController@clusters');
+Route::get('/teams/points/{team}', 'Teams\TeamsClusterController@points');
+Route::get('/teams/art-data/{team}', 'GlobalMap\GlobalMapController@artData');
 
 Route::get('/teams/members', 'Teams\TeamsController@members');
 Route::get('/teams/joined', 'Teams\TeamsController@joined');

--- a/tests/Feature/GetClustersTest.php
+++ b/tests/Feature/GetClustersTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Cluster;
+use Tests\TestCase;
+
+class GetClustersTest extends TestCase
+{
+
+    public function test_it_lists_global_clusters()
+    {
+        $globalCluster = Cluster::factory()->create(['zoom' => 2]);
+
+        $response = $this->get('/global/clusters?zoom=2');
+
+        $response->assertStatus(200);
+        $features = $response->json('features');
+        $this->assertCount(1, $features);
+        $this->assertEquals($globalCluster->lon, $features[0]['geometry']['coordinates'][0]);
+        $this->assertEquals($globalCluster->lat, $features[0]['geometry']['coordinates'][1]);
+    }
+}

--- a/tests/Unit/Commands/GenerateTeamClustersTest.php
+++ b/tests/Unit/Commands/GenerateTeamClustersTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Unit\Commands;
+
+use App\Models\Photo;
+use App\Models\TeamCluster;
+use App\Models\Teams\Team;
+use Tests\TestCase;
+
+class GenerateTeamClustersTest extends TestCase
+{
+    public function test_it_generates_team_clusters()
+    {
+        $team = Team::factory()->create(['total_images' => 5]);
+        Photo::factory(5)->create([
+            'lat' => 0,
+            'lon' => 0,
+            'team_id' => $team->id
+        ]);
+
+        $this->artisan('clusters:generate-team-clusters');
+
+        // Zoom levels from 2-16, 1 cluster per level
+        $this->assertEquals(15, TeamCluster::count());
+        $this->assertEquals($team->id, TeamCluster::first()->team_id);
+    }
+}


### PR DESCRIPTION
https://trello.com/c/ig4zVBBQ

Trying to fix the teams' map by removing the existing code that uses the leaflet marker cluster library, and replacing it with a simplified version of Supercluster called `ClusterMap.vue`.
The map is now hidden by default, and it's shown when you select a team from the dropdown, time filters do not apply.
Added a new database table called `team_clusters`, and a new generator command `php artisan clusters:generate-team-clusters`, scheduled to run every Monday at 00:20.
Refactored some code related to the GlobalMapController and GlobalClustersController, so that it's also used on the TeamClusterController.

Haven't modified the Supercluster.vue at all to keep the global map safe from breaking changes. I simply made a smaller copy of it, just to have it working.

The teams' maps are now working correctly, I do however get a console error sometimes when I zoom to the points level, and zoom out and in a few times, and then click on the map. The issue is caused by the Leaflet library unable to delete all its event listeners when we clear/remove the map when changing teams. There were no good solutions for that through the Github issues, but since maps are not used much and most users belong to only one team, this shouldn't be a big issue.
