### PR TITLE
Prevent token from being null

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -97,7 +97,10 @@ class RegisterController extends Controller
     */
     public function confirmEmail ($token)
     {
-        $verified = User::whereToken($token)->firstOrFail()->confirmEmail();
+        /** @var User $user */
+        $user = User::whereToken($token)->first();
+
+        $verified = $user && $user->confirmEmail();
 
         $auth = false;
         $user = null;

--- a/app/Mail/NewUserRegMail.php
+++ b/app/Mail/NewUserRegMail.php
@@ -38,7 +38,7 @@ class NewUserRegMail extends Mailable
     {
         // return $this->view('view.name');
         return $this->from('welcome@openlittermap.com')
-            ->subject('Register your email for Open Litter Map')
+            ->subject('Confirm your email on OpenLitterMap')
             ->view('auth.emails.confirm')
             ->with([
                 'token' => $this->user->token

--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -210,7 +210,7 @@ class User extends Authenticatable
     public function confirmEmail ()
     {
         $this->verified = true;
-        // $this->token = null; null token gives 404 when revisting the link
+        $this->token = null;
         $this->save();
 
         return $this->verified;

--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -210,8 +210,9 @@ class User extends Authenticatable
     public function confirmEmail ()
     {
         $this->verified = true;
-        $this->token = null;
+        // $this->token = null; null token gives 404 when revisting the link
         $this->save();
+
         return $this->verified;
     }
 

--- a/resources/views/auth/emails/confirm.blade.php
+++ b/resources/views/auth/emails/confirm.blade.php
@@ -386,7 +386,7 @@
                 <tr>
                     <td width="75%" align="center">
                         <br>
-                        &copy; OpenLitterMap & Contributors 2022.
+                        &copy; OpenLitterMap & Contributors {{ date('Y') }}.
                         <br/>
                         <br/>
                     </td>

--- a/resources/views/auth/emails/confirm.blade.php
+++ b/resources/views/auth/emails/confirm.blade.php
@@ -386,7 +386,7 @@
                 <tr>
                     <td width="75%" align="center">
                         <br>
-                        &copy; OpenLitterMap & Contributors 2020.
+                        &copy; OpenLitterMap & Contributors 2022.
                         <br/>
                         <br/>
                     </td>


### PR DESCRIPTION
Some users are saying that verify email token results in 404 

The first time I click the link it works, but additional clicks result in user not found 

Maybe we should keep the token and let them press it again ? 