### PR TITLE
Bugfix - Teams mobile API continued

### DIFF
--- a/app/Exceptions/PhotoAlreadyUploaded.php
+++ b/app/Exceptions/PhotoAlreadyUploaded.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class PhotoAlreadyUploaded extends Exception
+{
+    protected $message = "photo-already-uploaded";
+}

--- a/app/Http/Controllers/API/TeamsController.php
+++ b/app/Http/Controllers/API/TeamsController.php
@@ -14,7 +14,6 @@ use App\Http\Requests\Teams\UpdateTeamRequest;
 use App\Models\Teams\Team;
 use App\Models\Teams\TeamType;
 use App\Models\User\User;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Auth;
 
 class TeamsController extends Controller
@@ -28,14 +27,14 @@ class TeamsController extends Controller
     /**
      * Array of teams the user has joined
      *
-     * @return array<Team>
+     * @return array
      */
     public function list()
     {
         /** @var User $user */
         $user = Auth::user();
 
-        return $user->teams;
+        return $this->success(['teams' => $user->teams]);
     }
 
     /**
@@ -45,18 +44,18 @@ class TeamsController extends Controller
      * @param CreateTeamAction $action
      * @return array
      */
-    public function create(CreateTeamRequest $request, CreateTeamAction $action): array
+    public function create(CreateTeamRequest $request, CreateTeamAction $action)
     {
         /** @var User $user */
         $user = Auth::user();
 
         if ($user->remaining_teams === 0) {
-            abort(403, 'You have created your maximum number of teams!');
+            return $this->fail('max-teams-created');
         }
 
         $team = $action->run($user, $request->all());
 
-        return ['team' => $team];
+        return $this->success(['team' => $team]);
     }
 
     /**
@@ -67,15 +66,15 @@ class TeamsController extends Controller
      * @param Team $team
      * @return array
      */
-    public function update(UpdateTeamRequest $request, UpdateTeamAction $action, Team $team): array
+    public function update(UpdateTeamRequest $request, UpdateTeamAction $action, Team $team)
     {
         if (Auth::id() != $team->leader) {
-            abort(403, 'You are not the team leader!');
+            return $this->fail('member-not-allowed');
         }
 
         $team = $action->run($team, $request->all());
 
-        return ['team' => $team];
+        return $this->success(['team' => $team]);
     }
 
     /**
@@ -85,7 +84,7 @@ class TeamsController extends Controller
      * @param JoinTeamAction $action
      * @return array
      */
-    public function join(JoinTeamRequest $request, JoinTeamAction $action): array
+    public function join(JoinTeamRequest $request, JoinTeamAction $action)
     {
         /** @var User $user */
         $user = Auth::user();
@@ -94,15 +93,15 @@ class TeamsController extends Controller
 
         // Check the user is not already in the team
         if ($user->teams()->whereTeamId($team->id)->exists()) {
-            abort(403, 'You\'re already in this team!');
+            return $this->fail('already-a-member');
         }
 
         $action->run($user, $team);
 
-        return [
+        return $this->success([
             'team' => $team->fresh(),
             'activeTeam' => $user->fresh()->team()->first()
-        ];
+        ]);
     }
 
     /**
@@ -112,7 +111,7 @@ class TeamsController extends Controller
      * @param LeaveTeamAction $action
      * @return array
      */
-    public function leave(LeaveTeamRequest $request, LeaveTeamAction $action): array
+    public function leave(LeaveTeamRequest $request, LeaveTeamAction $action)
     {
         /** @var User $user */
         $user = Auth::user();
@@ -120,28 +119,51 @@ class TeamsController extends Controller
         $team = Team::find($request->team_id);
 
         if (!$user->teams()->whereTeamId($request->team_id)->exists()) {
-            abort(403, 'You are not part of this team!');
+            return $this->fail('not-a-member');
         }
 
         if ($team->users()->count() <= 1) {
-            abort(403, 'You are the only member of this team!');
+            return $this->fail('you-are-last-member');
         }
 
         $action->run($user, $team);
 
-        return [
+        return $this->success([
             'team' => $team->fresh(),
             'activeTeam' => $user->fresh()->team()->first()
-        ];
+        ]);
     }
 
     /**
      * Return the types of available teams
      *
-     * @return Collection
+     * @return array
      */
     public function types()
     {
-        return TeamType::select('id', 'team')->get();
+        return $this->success([
+            'types' => TeamType::select('id', 'team')->get()
+        ]);
+    }
+
+    /**
+     * Helper to output successful responses
+     * @param array $data
+     * @return array
+     */
+    private function success(array $data = []): array
+    {
+        return array_merge(['success' => true], $data);
+    }
+
+    /**
+     * Helper to output error responses
+     *
+     * @param string $message
+     * @return array
+     */
+    private function fail(string $message): array
+    {
+        return ['success' => false, 'message' => $message];
     }
 }

--- a/app/Http/Controllers/ApiPhotosController.php
+++ b/app/Http/Controllers/ApiPhotosController.php
@@ -7,10 +7,10 @@ use App\Actions\Photos\MakeImageAction;
 use App\Actions\Locations\ReverseGeocodeLocationAction;
 use App\Actions\Photos\UploadPhotoAction;
 use App\Events\ImageDeleted;
+use App\Exceptions\PhotoAlreadyUploaded;
 use App\Http\Requests\AddTagsApiRequest;
 use App\Models\Photo;
 use App\Models\User\User;
-use Exception;
 use GeoHash;
 use Carbon\Carbon;
 
@@ -21,11 +21,8 @@ use App\Events\Photo\IncrementPhotoMonth;
 
 use App\Helpers\Post\UploadHelper;
 
-use GuzzleHttp\Exception\GuzzleException;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 
 class ApiPhotosController extends Controller
@@ -87,7 +84,6 @@ class ApiPhotosController extends Controller
         );
      *
      * @return array
-     * @throws GuzzleException
      */
     public function store (Request $request) :array
     {
@@ -105,24 +101,28 @@ class ApiPhotosController extends Controller
             return ['success' => false, 'msg' => 'error-3'];
         }
 
-        $photo = $this->storePhoto($request);
+        try {
+            $photo = $this->storePhoto($request);
+        } catch (PhotoAlreadyUploaded $e) {
+            return ['success' => false, 'msg' => $e->getMessage()];
+        }
 
         return ['success' => true, 'photo_id' => $photo->id];
     }
 
     /**
-     * Temporary method to store a photo
-     * should be refactored back to the store method
+     * Stores a photo
      * This is to handle all APIs from mobile app versions
      *
      * @param Request $request
-     * @return Photo|JsonResponse
+     * @return Photo
+     * @throws PhotoAlreadyUploaded
      */
-    protected function storePhoto(Request $request)
+    protected function storePhoto(Request $request): Photo
     {
         $file = $request->file('photo');
         /** @var User $user */
-        $user = Auth::guard('api')->user();
+        $user = auth()->user();
 
         if (!$user->has_uploaded) $user->has_uploaded = 1;
 
@@ -149,9 +149,7 @@ class ApiPhotosController extends Controller
         // The user with id=1 needs to upload duplicate images for testing
         if (app()->environment() === "production" && $user->id != 1) {
             if (Photo::where(['user_id' => $user->id, 'datetime' => $date])->exists()) {
-                return response()->json(['errors' => [
-                    'photo' => 'You have already uploaded this file!'
-                ]]);
+                throw new PhotoAlreadyUploaded();
             }
         }
 
@@ -256,7 +254,8 @@ class ApiPhotosController extends Controller
      */
     public function addTags (AddTagsApiRequest $request)
     {
-        $user = Auth::guard('api')->user();
+        /** @var User $user */
+        $user = auth()->user();
         $photo = Photo::find($request->photo_id);
 
         if ($photo->user_id !== $user->id || $photo->verified > 0)
@@ -284,7 +283,6 @@ class ApiPhotosController extends Controller
      *
      * @param Request $request
      * @return array
-     * @throws GuzzleException
      */
     public function uploadWithTags (Request $request) :array
     {
@@ -304,12 +302,14 @@ class ApiPhotosController extends Controller
             return ['success' => false, 'msg' => 'error-3'];
         }
 
-        $photo = $this->storePhoto($request);
-
-        $userId = Auth::guard('api')->user()->id;
+        try {
+            $photo = $this->storePhoto($request);
+        } catch (PhotoAlreadyUploaded $e) {
+            return ['success' => false, 'msg' => $e->getMessage()];
+        }
 
         dispatch (new AddTags(
-            $userId,
+            auth()->id(),
             $photo->id,
             json_decode($request->tags, true),
             $request->picked_up
@@ -323,7 +323,8 @@ class ApiPhotosController extends Controller
      */
     public function check ()
     {
-        $user = Auth::guard('api')->user();
+        /** @var User $user */
+        $user = auth()->user();
 
         $photos = $user->photos()
             ->where('verified', 0)
@@ -339,7 +340,8 @@ class ApiPhotosController extends Controller
      */
     public function deleteImage(Request $request)
     {
-        $user = Auth::guard('api')->user();
+        /** @var User $user */
+        $user = auth()->user();
 
         $photo = Photo::findOrFail($request->photoId);
 

--- a/tests/Feature/Api/Teams/CreateTeamTest.php
+++ b/tests/Feature/Api/Teams/CreateTeamTest.php
@@ -54,14 +54,13 @@ class CreateTeamTest extends TestCase
             'identifier' => 'test-id',
             'team_type' => $this->teamTypeId
         ]);
-
         $response = $this->postJson('/api/teams/create', [
             'name' => 'team name 2',
             'identifier' => 'test-id-2',
             'team_type' => $this->teamTypeId
         ]);
 
-        $response->assertForbidden();
+        $response->assertJsonFragment(['success' => false, 'message' => 'max-teams-created']);
 
         $this->assertDatabaseCount('teams', 1);
     }

--- a/tests/Feature/Api/Teams/JoinTeamTest.php
+++ b/tests/Feature/Api/Teams/JoinTeamTest.php
@@ -64,7 +64,7 @@ class JoinTeamTest extends TestCase
             'identifier' => $team->identifier,
         ]);
 
-        $response->assertForbidden();
+        $response->assertJsonFragment(['success' => false, 'message' => 'already-a-member']);
 
         $this->assertEquals(1, $team->fresh()->members);
     }

--- a/tests/Feature/Api/Teams/LeaveTeamTest.php
+++ b/tests/Feature/Api/Teams/LeaveTeamTest.php
@@ -72,7 +72,7 @@ class LeaveTeamTest extends TestCase
             'team_id' => $team->id,
         ]);
 
-        $response->assertForbidden();
+        $response->assertJsonFragment(['success' => false, 'message' => 'not-a-member']);
     }
 
     public function test_a_user_is_assigned_their_next_team_as_active_if_they_leave_the_active_team()
@@ -154,7 +154,7 @@ class LeaveTeamTest extends TestCase
             'team_id' => $team->id,
         ]);
 
-        $response->assertForbidden();
+        $response->assertJsonFragment(['success' => false, 'message' => 'you-are-last-member']);
 
         $this->assertCount(1, $user->teams);
         $this->assertCount(1, $team->fresh()->users);

--- a/tests/Feature/Api/Teams/ListTeamsTest.php
+++ b/tests/Feature/Api/Teams/ListTeamsTest.php
@@ -18,26 +18,28 @@ class ListTeamsTest extends TestCase
         /** @var Team $team */
         $team = Team::factory()->create();
         $otherTeam = Team::factory()->create();
-
         $user->teams()->attach($team);
         $team->update(['members' => 2]);
 
         // User lists his teams ------------------------
-        $this->actingAs($user, 'api');
-
-        $this->getJson('/api/teams/list')
+        $response = $this->actingAs($user, 'api')
+            ->getJson('/api/teams/list')
             ->assertOk()
-            ->assertJsonCount(1)
-            ->assertJsonFragment(['id' => $team->id]);
+            ->json('teams');
+
+        $this->assertCount(1, $response);
+        $this->assertEquals($team->id, $response[0]['id']);
     }
 
     public function test_it_can_list_all_available_team_types()
     {
         $teamType = TeamType::factory()->create();
 
-        $this->getJson('/api/teams/types')
+        $response = $this->getJson('/api/teams/types')
             ->assertOk()
-            ->assertJsonCount(1)
-            ->assertJsonFragment(['id' => $teamType->id]);
+            ->json('types');
+
+        $this->assertCount(1, $response);
+        $this->assertEquals($teamType->id, $response[0]['id']);
     }
 }

--- a/tests/Feature/Api/Teams/UpdateTeamTest.php
+++ b/tests/Feature/Api/Teams/UpdateTeamTest.php
@@ -49,10 +49,8 @@ class UpdateTeamTest extends TestCase
         $team = Team::factory()->create([
             'leader' => $leader->id
         ]);
-
         $leader->teams()->attach($team);
         $member->teams()->attach($team);
-
         $newTeamName = 'New team name';
         $newTeamIdentifier = 'New identifier';
 
@@ -64,7 +62,7 @@ class UpdateTeamTest extends TestCase
             'identifier' => $newTeamIdentifier
         ]);
 
-        $response->assertForbidden();
+        $response->assertJsonFragment(['success' => false, 'message' => 'member-not-allowed']);
 
         // Members cannot update a team
         $this->actingAs($member);
@@ -74,7 +72,7 @@ class UpdateTeamTest extends TestCase
             'identifier' => $newTeamIdentifier
         ]);
 
-        $response->assertForbidden();
+        $response->assertJsonFragment(['success' => false, 'message' => 'member-not-allowed']);
     }
 
     public function test_fields_are_validated()

--- a/tests/Feature/Photos/UploadPhotoOnProductionTest.php
+++ b/tests/Feature/Photos/UploadPhotoOnProductionTest.php
@@ -71,7 +71,10 @@ class UploadPhotoOnProductionTest extends TestCase
             $this->getApiImageAttributes($imageAttributes)
         );
 
-        $response->assertStatus(500);
-        $response->assertSee("You have already uploaded this file!");
+        $response->assertOk();
+        $response->assertJson([
+            'success' => false,
+            'msg' => "photo-already-uploaded"
+        ]);
     }
 }


### PR DESCRIPTION
- Every Teams API response now has a 'success' key, true or false
- If the response has errors, you'll get at ['success' => true, 'message' => 'some-message']
- Available messages to return are:
```
Create team: 'max-teams-created'
Update team: 'member-not-allowed'
Join team: 'already-a-member'
Leave team: 'not-a-member', 'you-are-last-member'
```
The endpoints for 'teams/list' and 'teams/types' now have their response inside a 'teams' and 'types' key, respectively.

I also updated the response for duplicate images on production environments, now you will get a response structure similar to when everything goes well, this one: `[ 'success' => false, 'msg' => 'photo-already-uploaded']`