### PR TITLE
Feature - Mobile API for teams continued

### DIFF
--- a/app/Actions/Teams/DownloadTeamDataAction.php
+++ b/app/Actions/Teams/DownloadTeamDataAction.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Actions\Teams;
+
+use App\Exports\CreateCSVExport;
+use App\Jobs\EmailUserExportCompleted;
+use App\Models\Teams\Team;
+use App\Models\User\User;
+
+class DownloadTeamDataAction
+{
+
+    public function run(User $user, Team $team)
+    {
+        $path = now()->format('Y') .
+            "/" . now()->format('m') .
+            "/" . now()->format('d') .
+            "/" . now()->getTimestamp() .
+            '/_Team_OpenLitterMap.csv';  // 2020/10/25/unix/
+
+        /* Dispatch job to create CSV file for export */
+        (new CreateCSVExport(null, null, $team->id))
+            ->queue($path, 's3', null, ['visibility' => 'public'])
+            ->chain([
+                // These jobs are executed when above is finished.
+                new EmailUserExportCompleted($user->email, $path)
+                // new ....job
+            ]);
+    }
+}

--- a/app/Actions/Teams/ListTeamMembersAction.php
+++ b/app/Actions/Teams/ListTeamMembersAction.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Actions\Teams;
+
+
+use App\Models\Teams\Team;
+use Illuminate\Contracts\Pagination\Paginator;
+use Illuminate\Support\Facades\DB;
+
+class ListTeamMembersAction
+{
+    /**
+     * Load team members ranked by total litter
+     * We need to check the privacy settings for each user on the team,
+     * and only load the columns that each user has allowed.
+     */
+    public function run(Team $team): Paginator
+    {
+        return $team
+            ->users()
+            ->withPivot('total_photos', 'total_litter', 'updated_at', 'show_name_leaderboards', 'show_username_leaderboards')
+            ->orderBy('pivot_total_litter', 'desc')
+            ->simplePaginate(10, [
+                'users.id',
+                DB::raw("if(`team_user`.`show_name_leaderboards` = 1, `name`, '') as name"),
+                DB::raw("if(`team_user`.`show_username_leaderboards` = 1, `username`, '') as username"),
+                'users.active_team',
+                'users.updated_at',
+                'total_photos'
+            ]);
+    }
+}

--- a/app/Actions/Teams/SetActiveTeamAction.php
+++ b/app/Actions/Teams/SetActiveTeamAction.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Actions\Teams;
+
+use App\Models\User\User;
+
+class SetActiveTeamAction
+{
+    public function run(User $user, int $teamId)
+    {
+        $user->active_team = $teamId;
+        $user->save();
+    }
+}

--- a/app/Actions/Teams/ToggleLeaderboardVisibilityAction.php
+++ b/app/Actions/Teams/ToggleLeaderboardVisibilityAction.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Actions\Teams;
+
+use App\Models\Teams\Team;
+
+class ToggleLeaderboardVisibilityAction
+{
+
+    public function run(Team $team): Team
+    {
+        $team->leaderboards = !$team->leaderboards;
+        $team->save();
+
+        return $team;
+    }
+}

--- a/app/Http/Controllers/API/TeamsController.php
+++ b/app/Http/Controllers/API/TeamsController.php
@@ -148,9 +148,7 @@ class TeamsController extends Controller
         /** @var Team $team */
         $team = Team::find($request->team_id);
 
-        $isTeamMember = $user->teams()->where('team_id', $request->team_id)->exists();
-
-        if (!$isTeamMember) {
+        if (!$user->teams()->where('team_id', $request->team_id)->exists()) {
             return $this->fail('not-a-member');
         }
 

--- a/app/Http/Controllers/API/TeamsController.php
+++ b/app/Http/Controllers/API/TeamsController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\API;
 
 use App\Actions\Teams\CreateTeamAction;
+use App\Actions\Teams\DownloadTeamDataAction;
 use App\Actions\Teams\JoinTeamAction;
 use App\Actions\Teams\LeaveTeamAction;
 use App\Actions\Teams\ListTeamMembersAction;
@@ -189,6 +190,25 @@ class TeamsController extends Controller
         $result = $action->run($team);
 
         return $this->success(['result' => $result]);
+    }
+
+    /**
+     * The user wants to download data from a specific team
+     */
+    public function download (Request $request, DownloadTeamDataAction $action): array
+    {
+        /** @var User $user */
+        $user = auth()->user();
+        /** @var Team $team */
+        $team = Team::query()->findOrFail($request->team_id);
+
+        if (!$user->teams()->whereTeamId($request->team_id)->exists()) {
+            return $this->fail('not-a-member');
+        }
+
+        $action->run($user, $team);
+
+        return $this->success();
     }
 
     /**

--- a/app/Http/Controllers/API/TeamsController.php
+++ b/app/Http/Controllers/API/TeamsController.php
@@ -139,10 +139,8 @@ class TeamsController extends Controller
 
     /**
      * Sets the users currently active team
-     *
-     * @return array
      */
-    public function setActiveTeam(Request $request)
+    public function setActiveTeam(Request $request, SetActiveTeamAction $action): array
     {
         /** @var User $user */
         $user = auth()->user();
@@ -155,8 +153,6 @@ class TeamsController extends Controller
             return $this->fail('not-a-member');
         }
 
-        /** @var SetActiveTeamAction $action */
-        $action = app(SetActiveTeamAction::class);
         $action->run($user, $request->team_id);
 
         return $this->success(['team' => $team]);
@@ -179,7 +175,7 @@ class TeamsController extends Controller
     /**
      * Get paginated members for a team_id
      */
-    public function members(): array
+    public function members(ListTeamMembersAction $action): array
     {
         /** @var User $user */
         $user = auth()->user();
@@ -190,8 +186,6 @@ class TeamsController extends Controller
             return $this->fail('not-a-member');
         }
 
-        /** @var ListTeamMembersAction $action */
-        $action = app(ListTeamMembersAction::class);
         $result = $action->run($team);
 
         return $this->success(['result' => $result]);

--- a/app/Http/Controllers/API/TeamsController.php
+++ b/app/Http/Controllers/API/TeamsController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\API;
 use App\Actions\Teams\CreateTeamAction;
 use App\Actions\Teams\JoinTeamAction;
 use App\Actions\Teams\LeaveTeamAction;
+use App\Actions\Teams\ListTeamMembersAction;
 use App\Actions\Teams\SetActiveTeamAction;
 use App\Actions\Teams\UpdateTeamAction;
 use App\Http\Controllers\Controller;
@@ -173,6 +174,27 @@ class TeamsController extends Controller
         $user->save();
 
         return $this->success();
+    }
+
+    /**
+     * Get paginated members for a team_id
+     */
+    public function members(): array
+    {
+        /** @var User $user */
+        $user = auth()->user();
+        /** @var Team $team */
+        $team = Team::query()->findOrFail(request()->team_id);
+
+        if (!$user->teams()->where('team_id', request()->team_id)->exists()) {
+            return $this->fail('not-a-member');
+        }
+
+        /** @var ListTeamMembersAction $action */
+        $action = app(ListTeamMembersAction::class);
+        $result = $action->run($team);
+
+        return $this->success(['result' => $result]);
     }
 
     /**

--- a/app/Http/Controllers/API/TeamsController.php
+++ b/app/Http/Controllers/API/TeamsController.php
@@ -162,6 +162,20 @@ class TeamsController extends Controller
     }
 
     /**
+     * Clears the user's active team
+     */
+    public function inactivateTeams(): array
+    {
+        /** @var User $user */
+        $user = auth()->user();
+
+        $user->active_team = null;
+        $user->save();
+
+        return $this->success();
+    }
+
+    /**
      * Return the types of available teams
      *
      * @return array

--- a/app/Http/Controllers/Teams/TeamsController.php
+++ b/app/Http/Controllers/Teams/TeamsController.php
@@ -37,7 +37,7 @@ class TeamsController extends Controller
      *
      * @return array
      */
-    public function active (Request $request)
+    public function active (Request $request, SetActiveTeamAction $action)
     {
         /** @var User $user */
         $user = auth()->user();
@@ -48,8 +48,6 @@ class TeamsController extends Controller
             return ['success' => false];
         }
 
-        /** @var SetActiveTeamAction $action */
-        $action = app(SetActiveTeamAction::class);
         $action->run($user, $request->team_id);
 
         return ['success' => true, 'team' => $team];
@@ -207,7 +205,7 @@ class TeamsController extends Controller
     /**
      * Get paginated members for a team_id
      */
-    public function members (): array
+    public function members (ListTeamMembersAction $action): array
     {
         /** @var User $user */
         $user = auth()->user();
@@ -220,8 +218,6 @@ class TeamsController extends Controller
 
         $totalMembers = $team->users->count();
 
-        /** @var ListTeamMembersAction $action */
-        $action = app(ListTeamMembersAction::class);
         $result = $action->run($team);
 
         return [

--- a/app/Http/Controllers/Teams/TeamsLeaderboardController.php
+++ b/app/Http/Controllers/Teams/TeamsLeaderboardController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Teams;
 
 use App\Actions\Teams\ListTeamLeaderboardsAction;
+use App\Actions\Teams\ToggleLeaderboardVisibilityAction;
 use App\Http\Controllers\Controller;
 use App\Models\Teams\Team;
 use Illuminate\Database\Eloquent\Collection;
@@ -17,27 +18,25 @@ class TeamsLeaderboardController extends Controller
      * @param ListTeamLeaderboardsAction $action
      * @return Collection;
      */
-    public function index (ListTeamLeaderboardsAction $action)
+    public function index(ListTeamLeaderboardsAction $action)
     {
         return $action->run();
     }
 
     /**
      * Toggle team leaderboard
-     *
-     * @return mixed
      */
-    public function toggle (Request $request)
+    public function toggle(Request $request, ToggleLeaderboardVisibilityAction $action): array
     {
-        $team = Team::find($request->id);
+        /** @var Team $team */
+        $team = Team::query()->findOrFail($request->team_id);
 
-        if ($team->leader === auth()->user()->id)
-        {
-            $team->leaderboards = ! $team->leaderboards;
-
-            $team->save();
-
-            return ['success' => true];
+        if ($team->leader !== auth()->id()) {
+            return ['success' => false, 'visible' => $team->leaderboards];
         }
+
+        $action->run($team);
+
+        return ['success' => true, 'visible' => $team->leaderboards];
     }
 }

--- a/app/Http/Controllers/Teams/TeamsLeaderboardController.php
+++ b/app/Http/Controllers/Teams/TeamsLeaderboardController.php
@@ -32,7 +32,7 @@ class TeamsLeaderboardController extends Controller
         $team = Team::query()->findOrFail($request->team_id);
 
         if ($team->leader !== auth()->id()) {
-            return ['success' => false, 'visible' => $team->leaderboards];
+            return ['success' => false, 'message' => 'member-not-allowed'];
         }
 
         $action->run($team);

--- a/app/Jobs/EmailUserExportCompleted.php
+++ b/app/Jobs/EmailUserExportCompleted.php
@@ -35,6 +35,6 @@ class EmailUserExportCompleted implements ShouldQueue
      */
     public function handle()
     {
-        Mail::to($this->email)->send(new ExportWithLink($this->email, $this->path));
+        Mail::to($this->email)->send(new ExportWithLink($this->path));
     }
 }

--- a/app/Mail/ExportWithLink.php
+++ b/app/Mail/ExportWithLink.php
@@ -11,16 +11,15 @@ class ExportWithLink extends Mailable
 {
     use Queueable, SerializesModels;
 
-    public $email, $path;
+    public $path;
 
     /**
      * Create a new message instance.
      *
      * @return void
      */
-    public function __construct ($email, $path)
+    public function __construct ($path)
     {
-        $this->email = $email;
         $this->path = $path;
     }
 

--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -7,6 +7,9 @@ use App\Models\Teams\Team;
 use App\Payment;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Redis;
 use Laravel\Cashier\Billable;
 use Illuminate\Notifications\Notifiable;
@@ -186,20 +189,16 @@ class User extends Authenticatable
 
     /**
      * Get all payments
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function payments ()
+    public function payments (): HasMany
     {
         return $this->hasMany(Payment::class);
     }
 
     /**
      * Get all photos
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function photos ()
+    public function photos (): HasMany
     {
         return $this->hasMany(Photo::class);
     }
@@ -289,7 +288,7 @@ class User extends Authenticatable
     /**
      * Currently active team
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return BelongsTo
      */
     public function team ()
     {
@@ -301,7 +300,7 @@ class User extends Authenticatable
      *
      * Load extra columns on the pivot table
      */
-    public function teams ()
+    public function teams (): BelongsToMany
     {
         return $this->belongsToMany(Team::class)
             ->withTimestamps()

--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -17,6 +17,8 @@ use LaravelAndVueJS\Traits\LaravelPermissionToVueJS;
 
 /**
  * @property array<Team> $teams
+ * @property Team $team
+ * @property int $active_team
  */
 class User extends Authenticatable
 {

--- a/resources/js/store/modules/teams/actions.js
+++ b/resources/js/store/modules/teams/actions.js
@@ -443,7 +443,7 @@ export const actions = {
         const body = 'Visibility changed';
 
         await axios.post('/teams/leaderboard/visibility', {
-            id: payload
+            team_id: payload
         })
         .then(response => {
             console.log('toggle_leaderboard_visibility', response);

--- a/routes/api.php
+++ b/routes/api.php
@@ -97,6 +97,7 @@ Route::prefix('/teams')->group(function () {
     Route::get('/list', 'API\TeamsController@list');
     Route::get('/types', 'API\TeamsController@types');
     Route::patch('/update/{team}', 'API\TeamsController@update');
+    Route::post('/active', 'API\TeamsController@setActiveTeam');
     Route::post('/create', 'API\TeamsController@create');
     Route::post('/join', 'API\TeamsController@join');
     Route::post('/leave', 'API\TeamsController@leave');

--- a/routes/api.php
+++ b/routes/api.php
@@ -103,4 +103,5 @@ Route::prefix('/teams')->group(function () {
     Route::post('/inactivate', 'API\TeamsController@inactivateTeams');
     Route::post('/join', 'API\TeamsController@join');
     Route::post('/leave', 'API\TeamsController@leave');
+    Route::post('/leaderboard/visibility', 'Teams\TeamsLeaderboardController@toggle')->middleware('auth:api');
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -93,6 +93,7 @@ Route::post('/settings/privacy/toggle-previous-tags', 'ApiSettingsController@tog
 
 // Teams
 Route::prefix('/teams')->group(function () {
+    Route::get('/members', 'API\TeamsController@members');
     Route::get('/leaderboard', 'Teams\TeamsLeaderboardController@index')->middleware('auth:api');
     Route::get('/list', 'API\TeamsController@list');
     Route::get('/types', 'API\TeamsController@types');

--- a/routes/api.php
+++ b/routes/api.php
@@ -100,6 +100,7 @@ Route::prefix('/teams')->group(function () {
     Route::patch('/update/{team}', 'API\TeamsController@update');
     Route::post('/active', 'API\TeamsController@setActiveTeam');
     Route::post('/create', 'API\TeamsController@create');
+    Route::post('/download', 'API\TeamsController@download');
     Route::post('/inactivate', 'API\TeamsController@inactivateTeams');
     Route::post('/join', 'API\TeamsController@join');
     Route::post('/leave', 'API\TeamsController@leave');

--- a/routes/api.php
+++ b/routes/api.php
@@ -99,6 +99,7 @@ Route::prefix('/teams')->group(function () {
     Route::patch('/update/{team}', 'API\TeamsController@update');
     Route::post('/active', 'API\TeamsController@setActiveTeam');
     Route::post('/create', 'API\TeamsController@create');
+    Route::post('/inactivate', 'API\TeamsController@inactivateTeams');
     Route::post('/join', 'API\TeamsController@join');
     Route::post('/leave', 'API\TeamsController@leave');
 });

--- a/tests/Feature/Api/Teams/SetActiveTeamTest.php
+++ b/tests/Feature/Api/Teams/SetActiveTeamTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature\Api\Teams;
+
+use App\Models\Teams\Team;
+use App\Models\User\User;
+use Tests\TestCase;
+
+class SetActiveTeamTest extends TestCase
+{
+
+    public function test_a_user_can_set_a_team_as_their_active_team()
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        /** @var Team $team */
+        $team = Team::factory()->create();
+        $user->teams()->attach($team);
+        $this->assertNull($user->active_team);
+
+        $response = $this->actingAs($user, 'api')->postJson('/api/teams/active', [
+            'team_id' => $team->id,
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonFragment(['success' => true]);
+        $this->assertEquals($team->id, $user->fresh()->active_team);
+    }
+
+    public function test_a_user_can_only_set_an_active_team_if_they_are_a_member()
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        /** @var Team $team */
+        $team = Team::factory()->create();
+        $this->assertNull($user->active_team);
+
+        $response = $this->actingAs($user, 'api')->postJson('/api/teams/active', [
+            'team_id' => $team->id,
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonFragment(['success' => false, 'message' => 'not-a-member']);
+        $this->assertNull($user->fresh()->active_team);
+    }
+
+    public function test_a_user_can_only_set_an_active_team_if_the_team_exists()
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $this->assertNull($user->active_team);
+
+        $response = $this->actingAs($user, 'api')->postJson('/api/teams/active', [
+            'team_id' => 0,
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonFragment(['success' => false]);
+        $this->assertNull($user->fresh()->active_team);
+    }
+}

--- a/tests/Feature/Teams/DownloadTeamDataTest.php
+++ b/tests/Feature/Teams/DownloadTeamDataTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature\Teams;
+
+use App\Mail\ExportWithLink;
+use App\Models\Teams\Team;
+use App\Models\User\User;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class DownloadTeamDataTest extends TestCase
+{
+    public function routeDataProvider(): array
+    {
+        return [
+            ['guard' => 'web', 'route' => 'teams/download'],
+            ['guard' => 'api', 'route' => 'api/teams/download'],
+        ];
+    }
+
+    /**
+     * @dataProvider routeDataProvider
+     */
+    public function test_a_member_can_download_a_teams_data($guard, $route)
+    {
+        Mail::fake();
+        Storage::fake('s3');
+        Carbon::setTestNow(now());
+        /** @var User $member */
+        $member = User::factory()->create();
+        /** @var Team $team */
+        $team = Team::factory()->create();
+        $member->teams()->attach($team);
+
+        $response = $this->actingAs($member, $guard)->postJson($route . "?team_id=$team->id");
+
+        $response->assertOk();
+        $response->assertJson(['success' => true]);
+        Mail::assertSent(function (ExportWithLink $mail) use ($member) {
+            $expectedPath = now()->year . "/" . now()->format('m') . "/" . now()->format('d') . "/" . now()->getTimestamp() . "/_Team_OpenLitterMap.csv";
+            $this->assertTrue($mail->hasTo($member->email));
+            $this->assertEquals($expectedPath, $mail->path);
+            return true;
+        });
+    }
+
+    /**
+     * @dataProvider routeDataProvider
+     */
+    public function test_only_a_member_can_download_a_teams_data($guard, $route)
+    {
+        Mail::fake();
+        Storage::fake('s3');
+        /** @var User $nonMember */
+        $nonMember = User::factory()->create();
+        /** @var Team $team */
+        $team = Team::factory()->create();
+
+        $response = $this->actingAs($nonMember, $guard)->postJson($route . "?team_id=$team->id");
+
+        $response->assertOk();
+        $response->assertJsonFragment(['success' => false, 'message' => 'not-a-member']);
+        Mail::assertNothingSent();
+    }
+
+}

--- a/tests/Feature/Teams/InactivateTeamTest.php
+++ b/tests/Feature/Teams/InactivateTeamTest.php
@@ -8,25 +8,30 @@ use Tests\TestCase;
 
 class InactivateTeamTest extends TestCase
 {
-    public function test_a_user_can_inactivate_their_active_team()
+    public function routeDataProvider(): array
+    {
+        return [
+            ['guard' => 'web', 'route' => 'teams/inactivate'],
+            ['guard' => 'api', 'route' => 'api/teams/inactivate'],
+        ];
+    }
+
+    /**
+     * @dataProvider routeDataProvider
+     */
+    public function test_a_user_can_inactivate_their_active_team($guard, $route)
     {
         // User joins a team -------------------------
         /** @var Team $team */
         $team = Team::factory()->create();
         /** @var User $user */
-        $user = User::factory()->create([
-            'active_team' => $team->id
-        ]);
+        $user = User::factory()->create(['active_team' => $team->id]);
 
         // User inactivates their active team ------------------------
-        $this->actingAs($user);
+        $response = $this->actingAs($user, $guard)->postJson($route);
 
-        $response = $this->postJson('/teams/inactivate');
-
-        $response
-            ->assertOk()
-            ->assertJson(['success' => true]);
-
+        $response->assertOk();
+        $response->assertJson(['success' => true]);
         $this->assertNull($user->fresh()->active_team);
     }
 }

--- a/tests/Feature/Teams/ListTeamMembersTest.php
+++ b/tests/Feature/Teams/ListTeamMembersTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tests\Feature\Teams;
+
+use App\Models\Teams\Team;
+use App\Models\User\User;
+use Tests\TestCase;
+
+class ListTeamMembersTest extends TestCase
+{
+
+    public function routeDataProvider(): array
+    {
+        return [
+            ['guard' => 'web', 'route' => 'teams/members'],
+            ['guard' => 'api', 'route' => 'api/teams/members'],
+        ];
+    }
+
+    /**
+     * @dataProvider routeDataProvider
+     */
+    public function test_it_can_list_team_members($guard, $route)
+    {
+        /** @var Team $team */
+        $team = Team::factory()->create();
+        $users = User::factory(3)->create();
+        $users->each(function (User $user) use ($team) {
+            $user->teams()->attach($team);
+        });
+        $otherTeam = Team::factory()->create();
+        $otherMember = User::factory()->create();
+        $otherMember->teams()->attach($otherTeam);
+
+        $response = $this->actingAs($users->first(), $guard)->getJson($route . '?team_id=' . $team->id);
+
+        $response->assertOk();
+        $response->assertJsonFragment(['success' => true]);
+        $members = $response->json('result.data');
+        $this->assertCount(3, $members);
+        $this->assertEqualsCanonicalizing(
+            array_column($members, 'id'),
+            $users->pluck('id')->toArray()
+        );
+    }
+
+    /**
+     * @dataProvider routeDataProvider
+     */
+    public function test_team_members_have_the_correct_data($guard, $route)
+    {
+        /** @var Team $team */
+        $team = Team::factory()->create();
+        /** @var User $user */
+        $user = User::factory()->create();
+        $user->teams()->attach($team, [
+            'show_name_leaderboards' => true,
+            'show_username_leaderboards' => true
+        ]);
+
+        $response = $this->actingAs($user, $guard)->getJson($route . '?team_id=' . $team->id);
+
+        $member = $response->json('result.data.0');
+        $this->assertEquals($user->id, $member['id']);
+        $this->assertEquals($user->name, $member['name']);
+        $this->assertEquals($user->username, $member['username']);
+        $this->assertEquals($user->active_team, $member['active_team']);
+        $this->assertEquals($user->updated_at->toIsoString(), $member['updated_at']);
+        $this->assertEquals($user->total_photos, $member['pivot']['total_photos']);
+    }
+
+    /**
+     * @dataProvider routeDataProvider
+     */
+    public function test_it_hides_members_names_and_usernames_depending_on_their_settings($guard, $route)
+    {
+        /** @var Team $team */
+        $team = Team::factory()->create();
+        /** @var User $user */
+        $user = User::factory()->create();
+        $user->teams()->attach($team, [
+            'show_name_leaderboards' => false,
+            'show_username_leaderboards' => false
+        ]);
+
+        $response = $this->actingAs($user, $guard)->getJson($route . '?team_id=' . $team->id);
+        $member = $response->json('result.data.0');
+        $this->assertEmpty($member['name']);
+        $this->assertEmpty($member['username']);
+    }
+
+    /**
+     * @dataProvider routeDataProvider
+     */
+    public function test_only_members_of_a_team_can_view_its_members($guard, $route)
+    {
+        /** @var Team $team */
+        $team = Team::factory()->create();
+        /** @var User $user */
+        $user = User::factory()->create();
+        $user->teams()->attach($team);
+        /** @var User $nonMember */
+        $nonMember = User::factory()->create();
+
+        $response = $this->actingAs($nonMember, $guard)->getJson($route . '?team_id=' . $team->id);
+
+        $response->assertOk();
+        $response->assertJson(['success' => false, 'message' => 'not-a-member']);
+    }
+}

--- a/tests/Feature/Teams/SetActiveTeamTest.php
+++ b/tests/Feature/Teams/SetActiveTeamTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature\Teams;
+
+use App\Models\Teams\Team;
+use App\Models\User\User;
+use Tests\TestCase;
+
+class SetActiveTeamTest extends TestCase
+{
+
+    public function test_a_user_can_set_a_team_as_their_active_team()
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        /** @var Team $team */
+        $team = Team::factory()->create();
+        $user->teams()->attach($team);
+        $this->assertNull($user->active_team);
+
+        $response = $this->actingAs($user)->postJson('/teams/active', [
+            'team_id' => $team->id,
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonStructure(['success', 'team']);
+        $this->assertEquals($team->id, $user->fresh()->active_team);
+    }
+
+    public function test_a_user_can_only_set_an_active_team_if_they_are_a_member()
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        /** @var Team $team */
+        $team = Team::factory()->create();
+        $this->assertNull($user->active_team);
+
+        $response = $this->actingAs($user)->postJson('/teams/active', [
+            'team_id' => $team->id,
+        ]);
+
+        $response->assertOk();
+        $response->assertJson(['success' => false]);
+        $this->assertNull($user->fresh()->active_team);
+    }
+
+    public function test_a_user_can_only_set_an_active_team_if_the_team_exists()
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $this->assertNull($user->active_team);
+
+        $response = $this->actingAs($user)->postJson('/teams/active', [
+            'team_id' => 0,
+        ]);
+
+        $response->assertOk();
+        $response->assertJson(['success' => false]);
+        $this->assertNull($user->fresh()->active_team);
+    }
+}

--- a/tests/Feature/Teams/ToggleLeaderboardVisibilityTest.php
+++ b/tests/Feature/Teams/ToggleLeaderboardVisibilityTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature\Teams;
+
+use App\Models\Teams\Team;
+use App\Models\User\User;
+use Tests\TestCase;
+
+class ToggleLeaderboardVisibilityTest extends TestCase
+{
+
+    public function routeDataProvider(): array
+    {
+        return [
+            ['/teams/leaderboard/visibility', 'web'],
+            ['/api/teams/leaderboard/visibility', 'api'],
+        ];
+    }
+
+    /**
+     * @dataProvider routeDataProvider
+     */
+    public function test_it_can_toggle_the_visibility_of_teams_leaderboards($route, $guard)
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        /** @var Team $team */
+        $team = Team::factory()->create(['leader' => $user->id, 'leaderboards' => false]);
+
+        $response = $this->actingAs($user, $guard)->postJson($route, ['team_id' => $team->id]);
+
+        $response->assertOk();
+        $response->assertJson(['success' => true, 'visible' => true]);
+        $this->assertEquals(1, $team->fresh()->leaderboards);
+
+        $response = $this->actingAs($user, $guard)->postJson($route, ['team_id' => $team->id]);
+
+        $response->assertOk();
+        $response->assertJson(['success' => true, 'visible' => false]);
+        $this->assertEquals(0, $team->fresh()->leaderboards);
+    }
+
+    /**
+     * @dataProvider routeDataProvider
+     */
+    public function test_only_the_team_leader_can_toggle_the_visibility_of_teams_leaderboards($route, $guard)
+    {
+        $leader = User::factory()->create();
+        /** @var User $member */
+        $member = User::factory()->create();
+        /** @var Team $team */
+        $team = Team::factory()->create(['leader' => $leader->id, 'leaderboards' => false]);
+        $team->users()->attach($leader);
+        $team->users()->attach($member);
+
+        $response = $this->actingAs($member, $guard)->postJson($route, ['team_id' => $team->id]);
+
+        $response->assertOk();
+        $response->assertJson(['success' => false, 'visible' => false]);
+        $this->assertEquals(0, $team->fresh()->leaderboards);
+    }
+}

--- a/tests/Feature/Teams/ToggleLeaderboardVisibilityTest.php
+++ b/tests/Feature/Teams/ToggleLeaderboardVisibilityTest.php
@@ -56,7 +56,7 @@ class ToggleLeaderboardVisibilityTest extends TestCase
         $response = $this->actingAs($member, $guard)->postJson($route, ['team_id' => $team->id]);
 
         $response->assertOk();
-        $response->assertJson(['success' => false, 'visible' => false]);
+        $response->assertJson(['success' => false, 'message' => 'member-not-allowed']);
         $this->assertEquals(0, $team->fresh()->leaderboards);
     }
 }


### PR DESCRIPTION
https://trello.com/c/W7vsz8kN
https://trello.com/c/XW7cm27L
https://trello.com/c/ytqd1CnV

Continuing where we left from this PR #385 
Added support for these features:
- download team data
- show/hide team from leaderboards
- select active team
- disable active team
- list team members

We expose these endpoints:
```
GET /api/teams/members
	parameters: [ 'team_id' => 'required|integer']

	returns: [
                'success' => true,
		'result' => paginated results, will return you the next url, or the current page you're viewing, shows 10 results per page
	]
	or [
                'success' => false,
		'message' => 'not-a-member'
        ]

POST /api/teams/active
	parameters: [ 'team_id' => 'required|integer']

	returns: [
                'success' => true,
		'team' => The team object
	]
	or [
                'success' => false,
		'message' => 'not-a-member'
        ]

POST /api/teams/inactivate
	returns: [
                'success' => true
	]

POST /api/teams/leaderboard/visibility
	parameters: [ 'team_id' => 'required|integer']

	returns: [
                'success' => true,
		'visible' => true/false
	]
	or [
                'success' => false,
		'message' => 'member-not-allowed' (only the team leader is allowed)
        ]

POST /api/teams/download
	parameters: [ 'team_id' => 'required|integer']

	returns: [
                'success' => true
	]
	or [
                'success' => false,
		'message' => 'not-a-member'
        ]
```