### PR TITLE
Feature - Custom Tags

### DIFF
--- a/app/Actions/Photos/AddCustomTagsToPhotoAction.php
+++ b/app/Actions/Photos/AddCustomTagsToPhotoAction.php
@@ -9,8 +9,12 @@ class AddCustomTagsToPhotoAction
     /**
      * Adds custom tags to the photo.
      */
-    public function run(Photo $photo, array $tags): void
+    public function run(Photo $photo, ?array $tags): void
     {
+        if (empty($tags)) {
+            return;
+        }
+
         $photo->customTags()->createMany(
             collect($tags)->map(function ($tag) {
                 return ['tag' => $tag];

--- a/app/Actions/Photos/AddCustomTagsToPhotoAction.php
+++ b/app/Actions/Photos/AddCustomTagsToPhotoAction.php
@@ -9,7 +9,7 @@ class AddCustomTagsToPhotoAction
     /**
      * Adds custom tags to the photo.
      */
-    public function run(Photo $photo, ?array $tags): void
+    public function run(Photo $photo, array $tags): void
     {
         if (empty($tags)) {
             return;

--- a/app/Actions/Photos/AddCustomTagsToPhotoAction.php
+++ b/app/Actions/Photos/AddCustomTagsToPhotoAction.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Actions\Photos;
+
+use App\Models\Photo;
+
+class AddCustomTagsToPhotoAction
+{
+    /**
+     * Adds custom tags to the photo.
+     */
+    public function run(Photo $photo, array $tags): void
+    {
+        $photo->customTags()->createMany(
+            collect($tags)->map(function ($tag) {
+                return ['tag' => $tag];
+            })
+        );
+    }
+}

--- a/app/Actions/Photos/AddCustomTagsToPhotoAction.php
+++ b/app/Actions/Photos/AddCustomTagsToPhotoAction.php
@@ -9,10 +9,10 @@ class AddCustomTagsToPhotoAction
     /**
      * Adds custom tags to the photo.
      */
-    public function run(Photo $photo, array $tags): void
+    public function run(Photo $photo, array $tags): int
     {
         if (empty($tags)) {
-            return;
+            return 0;
         }
 
         $photo->customTags()->createMany(
@@ -20,5 +20,7 @@ class AddCustomTagsToPhotoAction
                 return ['tag' => $tag];
             })
         );
+
+        return count($tags);
     }
 }

--- a/app/Console/Commands/Users/UpdateRedisLocationsXp.php
+++ b/app/Console/Commands/Users/UpdateRedisLocationsXp.php
@@ -74,7 +74,8 @@ class UpdateRedisLocationsXp extends Command
             ->sum(function ($category) use ($photo) {
                 return $photo->$category->total();
             });
+        $xpFromCustomTags = $photo->customTags()->count();
 
-        return $xpFromPhoto + $xpFromTags;
+        return $xpFromPhoto + $xpFromTags + $xpFromCustomTags;
     }
 }

--- a/app/Exports/CreateCSVExport.php
+++ b/app/Exports/CreateCSVExport.php
@@ -67,12 +67,13 @@ class CreateCSVExport implements FromQuery, WithMapping, WithHeadings
             $result = array_merge($result, $model->types());
         }
 
-        return $result;
+        return array_merge($result, ['custom_tag_1', 'custom_tag_2', 'custom_tag_3']);
     }
 
     /**
      * Map over query response
      * This will insert the each row under each heading
+     * @param Photo $row
      */
     public function map ($row): array
     {
@@ -102,7 +103,7 @@ class CreateCSVExport implements FromQuery, WithMapping, WithHeadings
             }
         }
 
-        return $result;
+        return array_merge($result, $row->customTags->take(3)->pluck('tag')->toArray());
     }
 
     /**

--- a/app/Http/Controllers/API/TeamsController.php
+++ b/app/Http/Controllers/API/TeamsController.php
@@ -148,6 +148,10 @@ class TeamsController extends Controller
         /** @var Team $team */
         $team = Team::find($request->team_id);
 
+        if (!$team) {
+            return $this->fail('team-not-found');
+        }
+
         if (!$user->isMemberOfTeam($request->team_id)) {
             return $this->fail('not-a-member');
         }
@@ -181,6 +185,10 @@ class TeamsController extends Controller
         /** @var Team $team */
         $team = Team::query()->find(request()->team_id);
 
+        if (!$team) {
+            return $this->fail('team-not-found');
+        }
+
         if (!$user->isMemberOfTeam(request()->team_id)) {
             return $this->fail('not-a-member');
         }
@@ -199,6 +207,10 @@ class TeamsController extends Controller
         $user = auth()->user();
         /** @var Team $team */
         $team = Team::query()->find($request->team_id);
+
+        if (!$team) {
+            return $this->fail('team-not-found');
+        }
 
         if (!$user->isMemberOfTeam($request->team_id)) {
             return $this->fail('not-a-member');

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -204,7 +204,8 @@ class AdminController extends Controller
         $photo->total_litter = 0;
         $photo->save();
 
-        $this->addTags($request->categories, $photo->id);
+        // TODO categories and custom_tags are not provided in the front-end
+        $this->addTags($request->categories, [], $photo->id);
 
         event(new TagsVerifiedByAdmin($photo->id));
     }
@@ -226,7 +227,7 @@ class AdminController extends Controller
         $user->count_correctly_verified = 0; // At 100, the user earns a Littercoin
         $user->save();
 
-        $this->addTags($request->tags, $request->photoId);
+        $this->addTags($request->tags ?? [], $request->custom_tags ?? [], $request->photoId);
 
         event (new TagsVerifiedByAdmin($photo->id));
     }

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -313,6 +313,7 @@ class AdminController extends Controller
     private function filterPhotos(): Builder
     {
         return Photo::query()
+            ->with('customTags')
             ->whereNotIn('user_id', $this->usersToSkipVerification())
             ->when(request('country_id'), function (Builder $q) {
                 return $q->whereCountryId(request('country_id'));

--- a/app/Http/Controllers/ApiPhotosController.php
+++ b/app/Http/Controllers/ApiPhotosController.php
@@ -277,7 +277,7 @@ class ApiPhotosController extends Controller
         dispatch (new AddTags(
             $user->id,
             $photo->id,
-            $request->litter ?? $request->tags,
+            ($request->litter ?? $request->tags) ?? [],
             $request->custom_tags ?? [],
             $request->picked_up
         ));
@@ -310,7 +310,7 @@ class ApiPhotosController extends Controller
             auth()->id(),
             $photo->id,
             $request->tags,
-            $request->custom_tags ?? [],
+            $request->custom_tags,
             $request->picked_up
         ));
 

--- a/app/Http/Controllers/ApiPhotosController.php
+++ b/app/Http/Controllers/ApiPhotosController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use App\Actions\Locations\UpdateLeaderboardsForLocationAction;
-use App\Actions\Photos\AddCustomTagsToPhotoAction;
 use App\Actions\Photos\DeletePhotoAction;
 use App\Actions\Photos\MakeImageAction;
 use App\Actions\Locations\ReverseGeocodeLocationAction;
@@ -259,7 +258,7 @@ class ApiPhotosController extends Controller
      *
      * This is used by gallery photos
      */
-    public function addTags (AddTagsRequest $request, AddCustomTagsToPhotoAction $customTagsAction)
+    public function addTags (AddTagsRequest $request)
     {
         /** @var User $user */
         $user = auth()->user();
@@ -275,12 +274,11 @@ class ApiPhotosController extends Controller
             'request' => $request->all()
         ]);
 
-        $customTagsAction->run($photo, $request->custom_tags ?? []);
-
         dispatch (new AddTags(
             $user->id,
             $photo->id,
             $request->litter ?? $request->tags,
+            $request->custom_tags ?? [],
             $request->picked_up
         ));
 
@@ -291,10 +289,9 @@ class ApiPhotosController extends Controller
      * Upload Photo together with its tags
      *
      * @param UploadPhotoWithTagsRequest $request
-     * @param AddCustomTagsToPhotoAction $customTagsAction
      * @return array
      */
-    public function uploadWithTags (UploadPhotoWithTagsRequest $request, AddCustomTagsToPhotoAction $customTagsAction) :array
+    public function uploadWithTags (UploadPhotoWithTagsRequest $request) :array
     {
         $file = $request->file('photo');
 
@@ -309,12 +306,11 @@ class ApiPhotosController extends Controller
             return ['success' => false, 'msg' => $e->getMessage()];
         }
 
-        $customTagsAction->run($photo, $request->custom_tags ?? []);
-
         dispatch (new AddTags(
             auth()->id(),
             $photo->id,
             $request->tags,
+            $request->custom_tags ?? [],
             $request->picked_up
         ));
 

--- a/app/Http/Controllers/ApiPhotosController.php
+++ b/app/Http/Controllers/ApiPhotosController.php
@@ -275,7 +275,7 @@ class ApiPhotosController extends Controller
             'request' => $request->all()
         ]);
 
-        $customTagsAction->run($photo, $request->custom_tags);
+        $customTagsAction->run($photo, $request->custom_tags ?? []);
 
         dispatch (new AddTags(
             $user->id,
@@ -309,7 +309,7 @@ class ApiPhotosController extends Controller
             return ['success' => false, 'msg' => $e->getMessage()];
         }
 
-        $customTagsAction->run($photo, $request->custom_tags);
+        $customTagsAction->run($photo, $request->custom_tags ?? []);
 
         dispatch (new AddTags(
             auth()->id(),

--- a/app/Http/Controllers/Bbox/BoundingBoxController.php
+++ b/app/Http/Controllers/Bbox/BoundingBoxController.php
@@ -184,7 +184,7 @@ class BoundingBoxController extends Controller
         {
             $photo = Photo::find($request->photoId);
 
-            $this->addTags($request->tags, $request->photoId);
+            $this->addTags($request->tags, [], $request->photoId);
 
             // todo - dispatch event via horizon
             event(new TagsVerifiedByAdmin($photo->id));

--- a/app/Http/Controllers/PhotosController.php
+++ b/app/Http/Controllers/PhotosController.php
@@ -11,6 +11,7 @@ use App\Actions\Locations\ReverseGeocodeLocationAction;
 use App\Actions\Locations\UpdateLeaderboardsForLocationAction;
 use App\Events\ImageDeleted;
 use App\Http\Requests\AddTagsRequest;
+use App\Http\Requests\UploadPhotoRequest;
 use App\Models\User\User;
 use GeoHash;
 use Carbon\Carbon;
@@ -80,15 +81,11 @@ class PhotosController extends Controller
      * Move photo to AWS S3 in production || local in development
      * then persist new record to photos table
      *
-     * @param Request $request
+     * @param UploadPhotoRequest $request
      * @return bool[]
      */
-    public function store (Request $request)
+    public function store (UploadPhotoRequest $request): array
     {
-        $request->validate([
-           'file' => 'required|mimes:jpg,png,jpeg,heif,heic'
-        ]);
-
         /** @var User $user */
         $user = Auth::user();
 

--- a/app/Http/Controllers/PhotosController.php
+++ b/app/Http/Controllers/PhotosController.php
@@ -324,14 +324,14 @@ class PhotosController extends Controller
             abort(403, 'Forbidden');
         }
 
-        $customTagsAction->run($photo, $request->custom_tags ?? []);
+        $customTagsTotal = $customTagsAction->run($photo, $request->custom_tags ?? []);
 
         $litterTotals = $this->addTagsAction->run($photo, $request['tags']);
 
-        $user->xp += $litterTotals['all'];
+        $user->xp += $litterTotals['all'] + $customTagsTotal;
         $user->save();
 
-        $this->updateLeaderboardsAction->run($photo, $user->id, $litterTotals['all']);
+        $this->updateLeaderboardsAction->run($photo, $user->id, $litterTotals['all'] + $customTagsTotal);
 
         $photo->remaining = !$request->presence;
         $photo->total_litter = $litterTotals['litter'];

--- a/app/Http/Controllers/PhotosController.php
+++ b/app/Http/Controllers/PhotosController.php
@@ -324,7 +324,7 @@ class PhotosController extends Controller
             abort(403, 'Forbidden');
         }
 
-        $customTagsAction->run($photo, $request->custom_tags);
+        $customTagsAction->run($photo, $request->custom_tags ?? []);
 
         $litterTotals = $this->addTagsAction->run($photo, $request['tags']);
 

--- a/app/Http/Controllers/PhotosController.php
+++ b/app/Http/Controllers/PhotosController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Actions\Photos\AddCustomTagsToPhotoAction;
 use App\Actions\Photos\AddTagsToPhotoAction;
 use App\Actions\Photos\DeletePhotoAction;
 use App\Actions\Photos\MakeImageAction;
@@ -314,16 +315,19 @@ class PhotosController extends Controller
      * If the user is new, we submit the image for verification.
      * If the user is trusted, we can update OLM.
      */
-    public function addTags (AddTagsRequest $request)
+    public function addTags (AddTagsRequest $request, AddCustomTagsToPhotoAction $customTagsAction)
     {
         /** @var User $user */
         $user = Auth::user();
+        /** @var Photo $photo */
         $photo = Photo::findOrFail($request->photo_id);
 
         if ($photo->user_id !== $user->id || $photo->verified > 0)
         {
             abort(403, 'Forbidden');
         }
+
+        $customTagsAction->run($photo, $request->custom_tags);
 
         $litterTotals = $this->addTagsAction->run($photo, $request['tags']);
 

--- a/app/Http/Controllers/PhotosController.php
+++ b/app/Http/Controllers/PhotosController.php
@@ -326,7 +326,7 @@ class PhotosController extends Controller
 
         $customTagsTotal = $customTagsAction->run($photo, $request->custom_tags ?? []);
 
-        $litterTotals = $this->addTagsAction->run($photo, $request['tags']);
+        $litterTotals = $this->addTagsAction->run($photo, $request->tags ?? []);
 
         $user->xp += $litterTotals['all'] + $customTagsTotal;
         $user->save();

--- a/app/Http/Controllers/User/UserPhotoController.php
+++ b/app/Http/Controllers/User/UserPhotoController.php
@@ -28,7 +28,7 @@ class UserPhotoController extends Controller
 
         foreach ($photos as $photo)
         {
-             dispatch (new AddTagsToPhoto($photo->id, $request->tags));
+             dispatch (new AddTagsToPhoto($photo->id, $request->tags, $request->custom_tags ?? []));
         }
 
         return ['success' => true];

--- a/app/Http/Controllers/User/UserPhotoController.php
+++ b/app/Http/Controllers/User/UserPhotoController.php
@@ -28,7 +28,7 @@ class UserPhotoController extends Controller
 
         foreach ($photos as $photo)
         {
-             dispatch (new AddTagsToPhoto($photo->id, $request->tags, $request->custom_tags ?? []));
+             dispatch (new AddTagsToPhoto($photo->id, $request->tags ?? [], $request->custom_tags ?? []));
         }
 
         return ['success' => true];

--- a/app/Http/Requests/AddTagsRequest.php
+++ b/app/Http/Requests/AddTagsRequest.php
@@ -16,7 +16,9 @@ class AddTagsRequest extends FormRequest
         return [
             'photo_id' => 'required|exists:photos,id',
             'tags' => 'required|array',
-            'presence' => 'required|boolean'
+            'presence' => 'required|boolean',
+            'custom_tags' => 'nullable|array|max:3',
+            'custom_tags.*' => 'distinct:ignore_case|min:3|max:100'
         ];
     }
 }

--- a/app/Http/Requests/AddTagsRequest.php
+++ b/app/Http/Requests/AddTagsRequest.php
@@ -15,9 +15,9 @@ class AddTagsRequest extends FormRequest
     {
         return [
             'photo_id' => 'required|exists:photos,id',
-            'tags' => 'required|array',
+            'tags' => 'required_without:custom_tags|array',
             'presence' => 'required|boolean',
-            'custom_tags' => 'nullable|array|max:3',
+            'custom_tags' => 'required_without:tags|array|max:3',
             'custom_tags.*' => 'distinct:ignore_case|min:3|max:100'
         ];
     }

--- a/app/Http/Requests/Api/AddTagsRequest.php
+++ b/app/Http/Requests/Api/AddTagsRequest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace App\Http\Requests;
+namespace App\Http\Requests\Api;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class AddTagsApiRequest extends FormRequest
+class AddTagsRequest extends FormRequest
 {
     /**
      * Get the validation rules that apply to the request.
@@ -17,7 +17,9 @@ class AddTagsApiRequest extends FormRequest
             'photo_id' => 'required|exists:photos,id',
             'litter' => 'required_without:tags|array',
             'tags' => 'required_without:litter|array',
-            'picked_up' => 'nullable|boolean'
+            'picked_up' => 'nullable|boolean',
+            'custom_tags' => 'nullable|array|max:3',
+            'custom_tags.*' => 'distinct:ignore_case|min:3|max:100'
         ];
     }
 }

--- a/app/Http/Requests/Api/AddTagsRequest.php
+++ b/app/Http/Requests/Api/AddTagsRequest.php
@@ -15,10 +15,10 @@ class AddTagsRequest extends FormRequest
     {
         return [
             'photo_id' => 'required|exists:photos,id',
-            'litter' => 'required_without:tags|array',
-            'tags' => 'required_without:litter|array',
+            'litter' => 'required_without_all:tags,custom_tags|array',
+            'tags' => 'required_without_all:litter,custom_tags|array',
             'picked_up' => 'nullable|boolean',
-            'custom_tags' => 'nullable|array|max:3',
+            'custom_tags' => 'required_without_all:tags,litter|array|max:3',
             'custom_tags.*' => 'distinct:ignore_case|min:3|max:100'
         ];
     }

--- a/app/Http/Requests/Api/UploadPhotoWithTagsRequest.php
+++ b/app/Http/Requests/Api/UploadPhotoWithTagsRequest.php
@@ -28,9 +28,9 @@ class UploadPhotoWithTagsRequest extends FormRequest
             'lat' => 'required|numeric',
             'lon' => 'required|numeric',
             'date' => 'required',
-            'tags' => 'required|array',
+            'tags' => 'required_without:custom_tags|array',
             'picked_up' => 'nullable|boolean',
-            'custom_tags' => 'nullable|array|max:3',
+            'custom_tags' => 'required_without:tags|array|max:3',
             'custom_tags.*' => 'distinct:ignore_case|min:3|max:100'
         ];
     }

--- a/app/Http/Requests/Api/UploadPhotoWithTagsRequest.php
+++ b/app/Http/Requests/Api/UploadPhotoWithTagsRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UploadPhotoWithTagsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'photo' => 'required|mimes:jpg,png,jpeg,heif,heic',
+            'lat' => 'required|numeric',
+            'lon' => 'required|numeric',
+            'date' => 'required',
+            'tags' => 'required|array',
+            'picked_up' => 'nullable|boolean',
+            'custom_tags' => 'nullable|array|max:3',
+            'custom_tags.*' => 'distinct:ignore_case|min:3|max:100'
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'tags' => json_decode($this->tags, true) ?? [],
+            'custom_tags' => json_decode($this->custom_tags, true) ?? []
+        ]);
+    }
+}

--- a/app/Http/Requests/UploadPhotoRequest.php
+++ b/app/Http/Requests/UploadPhotoRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UploadPhotoRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'file' => 'required|mimes:jpg,png,jpeg,heif,heic'
+        ];
+    }
+}

--- a/app/Jobs/Photos/AddTagsToPhoto.php
+++ b/app/Jobs/Photos/AddTagsToPhoto.php
@@ -52,18 +52,18 @@ class AddTagsToPhoto implements ShouldQueue
 
         /** @var AddCustomTagsToPhotoAction $addCustomTagsAction */
         $addCustomTagsAction = app(AddCustomTagsToPhotoAction::class);
-        $addCustomTagsAction->run($photo, $this->customTags);
+        $customTagsTotals = $addCustomTagsAction->run($photo, $this->customTags);
 
         /** @var AddTagsToPhotoAction $addTagsAction */
         $addTagsAction = app(AddTagsToPhotoAction::class);
         $litterTotals = $addTagsAction->run($photo, $this->tags);
 
-        $user->xp += $litterTotals['all'];
+        $user->xp += $litterTotals['all'] + $customTagsTotals;
         $user->save();
 
         /** @var UpdateLeaderboardsForLocationAction $updateLeaderboardsAction */
         $updateLeaderboardsAction = app(UpdateLeaderboardsForLocationAction::class);
-        $updateLeaderboardsAction->run($photo, $user->id, $litterTotals['all']);
+        $updateLeaderboardsAction->run($photo, $user->id, $litterTotals['all'] + $customTagsTotals);
 
         $photo->remaining = false; // todo
         $photo->total_litter = $litterTotals['litter'];

--- a/app/Jobs/Photos/AddTagsToPhoto.php
+++ b/app/Jobs/Photos/AddTagsToPhoto.php
@@ -18,7 +18,11 @@ class AddTagsToPhoto implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public $photoId, $tags;
+    public $photoId;
+    /**
+     * @var array
+     */
+    public $tags;
     /**
      * @var array
      */
@@ -29,7 +33,7 @@ class AddTagsToPhoto implements ShouldQueue
      *
      * @return void
      */
-    public function __construct ($photoId, $tags, array $customTags = [])
+    public function __construct ($photoId, array $tags = [], array $customTags = [])
     {
         $this->photoId = $photoId;
         $this->tags = $tags;

--- a/app/Models/CustomTag.php
+++ b/app/Models/CustomTag.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CustomTag extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+}

--- a/app/Models/Photo.php
+++ b/app/Models/Photo.php
@@ -3,13 +3,12 @@
 namespace App\Models;
 
 use App\Models\AI\Annotation;
-use App\Models\Litter\Categories\Art;
 use App\Models\Litter\Categories\Brand;
-use App\Models\Litter\Categories\Smoking;
 use App\Models\Teams\Team;
 use App\Models\User\User;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Photo extends Model
 {
@@ -322,4 +321,9 @@ class Photo extends Model
     // public function politics() {
     //     return $this->belongsTo('App\Models\Litter\Categories\Politicals', 'political_id', 'id');
     // }
+
+    public function customTags(): HasMany
+    {
+        return $this->hasMany(CustomTag::class);
+    }
 }

--- a/app/Models/Photo.php
+++ b/app/Models/Photo.php
@@ -6,10 +6,14 @@ use App\Models\AI\Annotation;
 use App\Models\Litter\Categories\Brand;
 use App\Models\Teams\Team;
 use App\Models\User\User;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
+/**
+ * @property Collection $customTags
+ */
 class Photo extends Model
 {
     use HasFactory;

--- a/app/Traits/AddTagsTrait.php
+++ b/app/Traits/AddTagsTrait.php
@@ -3,6 +3,7 @@
 namespace App\Traits;
 
 use App\Actions\Locations\UpdateLeaderboardsForLocationAction;
+use App\Actions\Photos\AddCustomTagsToPhotoAction;
 use App\Actions\Photos\AddTagsToPhotoAction;
 use App\Actions\Photos\DeleteTagsFromPhotoAction;
 use App\Models\Photo;
@@ -13,9 +14,10 @@ trait AddTagsTrait
     /**
      * Add or Update tags on an image
      * @param array $tags
+     * @param array $customTags
      * @param int $photoId
      */
-    public function addTags ($tags, $photoId)
+    public function addTags ($tags, $customTags, $photoId)
     {
         $photo = Photo::find($photoId);
         $user = User::find($photo->user_id);
@@ -30,8 +32,13 @@ trait AddTagsTrait
         $addTagsAction = app(AddTagsToPhotoAction::class);
         $litterTotals = $addTagsAction->run($photo, $tags);
 
+        // Add the new custom tags
+        /** @var AddCustomTagsToPhotoAction $addCustomTagsAction */
+        $addCustomTagsAction = app(AddCustomTagsToPhotoAction::class);
+        $customTagsTotal = $addCustomTagsAction->run($photo, $customTags);
+
         // Decrement the XP since old tags no longer exist
-        $xpDifference = $litterTotals['all'] - $deletedTags['all'];
+        $xpDifference = $litterTotals['all'] + $customTagsTotal - $deletedTags['all'];
 
         $user->xp += $xpDifference;
         $user->xp = max(0, $user->xp);

--- a/database/migrations/2022_02_03_173026_create_custom_tags_table.php
+++ b/database/migrations/2022_02_03_173026_create_custom_tags_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCustomTagsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('custom_tags', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('photo_id');
+            $table->string('tag', 100)->index();
+            $table->timestamps();
+
+            $table->foreign('photo_id')->references('id')->on('photos');
+            $table->unique(['photo_id', 'tag']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('custom_tags');
+    }
+}

--- a/resources/js/components/Litter/AddTags.vue
+++ b/resources/js/components/Litter/AddTags.vue
@@ -23,6 +23,7 @@
             <div v-if="showCustomTags" class="is-flex-grow-1">
                 <input
                     class="input is-fullwidth"
+                    :class="customTagsError ? 'is-danger' : ''"
                     ref="customTagsInput"
                     type="text"
                     min="3"
@@ -31,6 +32,7 @@
                     @focus="onFocusCustomTags"
                     @keydown.enter="searchCustomTag"
                 >
+                <p v-if="customTagsError" class="help has-text-left">{{ customTagsError }}</p>
             </div>
         </div>
 
@@ -343,6 +345,14 @@ export default {
         },
 
         /**
+         * The latest error related to custom tags
+         */
+        customTagsError ()
+        {
+            return this.$store.state.litter.customTagsError;
+        },
+
+        /**
          * Get / Set the current tag (category -> tag)
          */
         tag: {
@@ -544,7 +554,15 @@ export default {
         {
             let customTag = this.$refs.customTagsInput.value;
 
-            if (customTag.length < 3 || customTag.length > 100) return;
+            if (customTag.length < 3) {
+                this.$store.commit('setCustomTagsError', 'It needs to be at least 3 characters long.');
+                return;
+            }
+
+            if (customTag.length > 100) {
+                this.$store.commit('setCustomTagsError', 'It needs to be at most 100 characters long.');
+                return;
+            }
 
             this.customTag = customTag;
 

--- a/resources/js/components/Litter/AddTags.vue
+++ b/resources/js/components/Litter/AddTags.vue
@@ -1,8 +1,8 @@
 <template>
     <div>
         <!-- Search all tags -->
-        <div class="flex">
-            <div class="is-flex-grow-3">
+        <div class="flex flex-column-mobile">
+            <div class="is-flex-grow-3 search-container">
                 <div class="select is-fullwidth">
                     <vue-simple-suggest
                         ref="search"
@@ -20,7 +20,7 @@
                     />
                 </div>
             </div>
-            <div class="is-flex-grow-1 ml-2">
+            <div v-if="showCustomTags" class="is-flex-grow-1">
                 <input
                     class="input is-fullwidth"
                     ref="customTagsInput"
@@ -151,7 +151,8 @@ export default {
         'id': { type: Number, required: true },
         'admin': Boolean,
         'annotations': { type: Boolean, required: false },
-        'isVerifying': { type: Boolean, required: false }
+        'isVerifying': { type: Boolean, required: false },
+        'showCustomTags': { type: Boolean, required: false, default: true }
     },
     created ()
     {
@@ -604,6 +605,10 @@ export default {
         flex-grow: 1;
     }
 
+    .search-container {
+        margin-right: 4px;
+    }
+
     @media (max-width: 500px)
     {
         .hide-br {
@@ -611,6 +616,13 @@ export default {
         }
         .v-select {
             margin-top: 10px;
+        }
+        .flex-column-mobile {
+            flex-direction: column;
+        }
+        .search-container {
+            margin-right: 0;
+            margin-bottom: 4px;
         }
     }
 

--- a/resources/js/components/Litter/AddTags.vue
+++ b/resources/js/components/Litter/AddTags.vue
@@ -108,7 +108,7 @@
 
             <button
                 v-show="! admin && this.id !== 0"
-                :disabled="checkTags"
+                :disabled="!hasAddedTags"
                 :class="button"
                 @click="submit"
             >{{ $t('common.submit') }}</button>
@@ -311,13 +311,18 @@ export default {
         // },
 
         /**
-         * Disable button if true
+         * Disable button if false
          */
-        checkTags ()
+        hasAddedTags ()
         {
-            if (this.processing) return true;
+            if (this.processing) return false;
 
-            return Object.keys(this.$store.state.litter.tags[this.id] || {}).length === 0;
+            let tags = this.$store.state.litter.tags;
+            let customTags = this.$store.state.litter.customTags;
+            let hasTags = tags && tags[this.id] && Object.keys(tags[this.id]).length;
+            let hasCustomTags = customTags && customTags[this.id] && customTags[this.id].length;
+
+            return hasTags || hasCustomTags;
         },
 
         /**

--- a/resources/js/components/Litter/RecentTags.vue
+++ b/resources/js/components/Litter/RecentTags.vue
@@ -80,15 +80,12 @@ export default {
         {
             let quantity = 1;
 
-            if (this.$store.state.litter.tags.hasOwnProperty(this.photoId))
-            {
-                if (this.$store.state.litter.tags[this.photoId].hasOwnProperty(category))
-                {
-                    if (this.$store.state.litter.tags[this.photoId][category].hasOwnProperty(tag))
-                    {
-                        quantity = (this.$store.state.litter.tags[this.photoId][category][tag] + 1);
-                    }
-                }
+            if (
+                this.$store.state.litter.tags.hasOwnProperty(this.photoId) &&
+                this.$store.state.litter.tags[this.photoId].hasOwnProperty(category) &&
+                this.$store.state.litter.tags[this.photoId][category].hasOwnProperty(tag)
+            ) {
+                quantity = parseInt(this.$store.state.litter.tags[this.photoId][category][tag]) + 1;
             }
 
             this.$store.commit('addTag', {

--- a/resources/js/components/Litter/RecentTags.vue
+++ b/resources/js/components/Litter/RecentTags.vue
@@ -1,6 +1,19 @@
 <template>
-    <div class="tags-container" v-if="Object.keys(recentTags).length > 0">
+    <div class="tags-container" v-if="Object.keys(recentTags).length > 0 || recentCustomTags.length > 0">
         <p class="mb-5 has-text-weight-bold">{{ $t('tags.recently-tags') }}</p>
+
+        <div v-if="recentCustomTags.length">
+            <p>Custom Tags</p>
+
+            <transition-group name="list" class="recent-tags" tag="div">
+                <div
+                    v-for="(tag, index) in recentCustomTags"
+                    class="litter-tag"
+                    :key="index"
+                    @click="addRecentCustomTag(tag)"
+                ><p class="has-text-white">{{ tag }}</p></div>
+            </transition-group>
+        </div>
 
         <div v-for="category in Object.keys(recentTags)">
             <p>{{ getCategoryName(category) }}</p>
@@ -28,6 +41,14 @@ export default {
         recentTags ()
         {
             return this.$store.state.litter.recentTags;
+        },
+
+        /**
+         * The most recent custom tags the user has applied
+         */
+        recentCustomTags ()
+        {
+            return this.$store.state.litter.recentCustomTags;
         },
     },
     methods: {
@@ -75,6 +96,17 @@ export default {
                 category,
                 tag,
                 quantity
+            });
+        },
+
+        /**
+         * Add a recent custom tag to the existing tags
+         */
+        addRecentCustomTag (tag)
+        {
+            this.$store.commit('addCustomTag', {
+                photoId: this.photoId,
+                customTag: tag
             });
         },
     }

--- a/resources/js/components/Litter/RecentTags.vue
+++ b/resources/js/components/Litter/RecentTags.vue
@@ -1,8 +1,8 @@
 <template>
-    <div class="tags-container" v-if="Object.keys(recentTags).length > 0 || recentCustomTags.length > 0">
+    <div class="tags-container" v-if="Object.keys(recentTags).length > 0 || (showCustomTags && recentCustomTags.length)">
         <p class="mb-5 has-text-weight-bold">{{ $t('tags.recently-tags') }}</p>
 
-        <div v-if="recentCustomTags.length">
+        <div v-if="showCustomTags && recentCustomTags.length">
             <p>Custom Tags</p>
 
             <transition-group name="list" class="recent-tags" tag="div">
@@ -33,7 +33,13 @@
 <script>
 export default {
     name: 'RecentTags',
-    props: ['photoId'],
+    props: {
+        photoId: Number,
+        showCustomTags: {
+            type: Boolean,
+            default: true
+        }
+    },
     computed: {
         /**
          * The most recent tags the user has applied

--- a/resources/js/components/Litter/RecentTags.vue
+++ b/resources/js/components/Litter/RecentTags.vue
@@ -7,9 +7,9 @@
 
             <transition-group name="list" class="recent-tags" tag="div">
                 <div
-                    v-for="(tag, index) in recentCustomTags"
+                    v-for="tag in recentCustomTags"
                     class="litter-tag"
-                    :key="index"
+                    :key="tag"
                     @click="addRecentCustomTag(tag)"
                 ><p class="has-text-white">{{ tag }}</p></div>
             </transition-group>

--- a/resources/js/components/Litter/RecentTags.vue
+++ b/resources/js/components/Litter/RecentTags.vue
@@ -1,8 +1,8 @@
 <template>
-    <div class="tags-container" v-if="Object.keys(recentTags).length > 0 || (showCustomTags && recentCustomTags.length)">
+    <div class="tags-container" v-if="Object.keys(recentTags).length > 0 || recentCustomTags.length">
         <p class="mb-5 has-text-weight-bold">{{ $t('tags.recently-tags') }}</p>
 
-        <div v-if="showCustomTags && recentCustomTags.length">
+        <div v-if="recentCustomTags.length">
             <p>Custom Tags</p>
 
             <transition-group name="list" class="recent-tags" tag="div">
@@ -33,13 +33,7 @@
 <script>
 export default {
     name: 'RecentTags',
-    props: {
-        photoId: Number,
-        showCustomTags: {
-            type: Boolean,
-            default: true
-        }
-    },
+    props: ['photoId'],
     computed: {
         /**
          * The most recent tags the user has applied

--- a/resources/js/components/Litter/Tags.vue
+++ b/resources/js/components/Litter/Tags.vue
@@ -1,5 +1,17 @@
 <template>
     <div>
+        <div v-if="customTags.length" >
+            <span class="category">Custom Tags</span>
+            <ul class="container">
+                <li v-for="tag in customTags" class="admin-item">
+                    <span
+                        class="tag is-medium has-background-link has-text-white litter-tag"
+                        @click="removeCustomTag(tag)"
+                        v-html="tag"
+                    />
+                </li>
+            </ul>
+        </div>
         <ul class="container">
             <li v-for="category in categories" class="admin-item">
                 <!-- Translated Category Title -->
@@ -43,6 +55,14 @@ export default {
 
             return categories;
         },
+
+        /**
+         * Custom tags that the user has selected
+         */
+        customTags ()
+        {
+            return this.$store.state.litter.customTags[this.photoId] || [];
+        },
     },
     methods: {
 
@@ -80,6 +100,17 @@ export default {
                 photoId: this.photoId,
                 category,
                 tag_key
+            });
+        },
+
+        /**
+         * Remove the custom tag
+         */
+        removeCustomTag (tag)
+        {
+            this.$store.commit('removeCustomTag', {
+                photoId: this.photoId,
+                customTag: tag
             });
         }
     }

--- a/resources/js/components/Litter/Tags.vue
+++ b/resources/js/components/Litter/Tags.vue
@@ -30,14 +30,7 @@
 /*** Tags (previously AddedItems) is quite similar to AdminItems except here we remove the tag, on AdminItems we reset the tag.*/
 export default {
     name: 'Tags',
-    props: {
-        photoId: Number,
-        admin: Boolean,
-        canRemoveCustomTags: {
-            type: Boolean,
-            default: true
-        }
-    },
+    props: ['photoId', 'admin'],
     computed: {
 
         /**
@@ -95,10 +88,7 @@ export default {
          */
         removeTag (category, tag_key)
         {
-            let commit = '';
-
-            if (this.admin)  commit = 'resetTag';
-            else commit = 'removeTag';
+            let commit = this.admin ? 'resetTag' : 'removeTag';
 
             this.$store.commit(commit, {
                 photoId: this.photoId,
@@ -112,8 +102,6 @@ export default {
          */
         removeCustomTag (tag)
         {
-            if (!this.canRemoveCustomTags) return;
-
             this.$store.commit('removeCustomTag', {
                 photoId: this.photoId,
                 customTag: tag

--- a/resources/js/components/Litter/Tags.vue
+++ b/resources/js/components/Litter/Tags.vue
@@ -1,18 +1,15 @@
 <template>
     <div>
-        <div v-if="customTags.length" >
-            <span class="category">Custom Tags</span>
-            <ul class="container">
-                <li v-for="tag in customTags" class="admin-item">
-                    <span
-                        class="tag is-medium has-background-link has-text-white litter-tag"
-                        @click="removeCustomTag(tag)"
-                        v-html="tag"
-                    />
-                </li>
-            </ul>
-        </div>
         <ul class="container">
+            <li v-if="customTags.length" class="admin-item">
+                <span class="category">Custom Tags</span>
+                <span v-for="tag in customTags"
+                      class="tag is-medium has-background-link has-text-white litter-tag"
+                      @click="removeCustomTag(tag)"
+                      v-html="tag"
+                />
+            </li>
+
             <li v-for="category in categories" class="admin-item">
                 <!-- Translated Category Title -->
                 <span class="category">{{ getCategory(category.category) }}</span>
@@ -33,7 +30,14 @@
 /*** Tags (previously AddedItems) is quite similar to AdminItems except here we remove the tag, on AdminItems we reset the tag.*/
 export default {
     name: 'Tags',
-    props: ['admin', 'photoId'], // bool
+    props: {
+        photoId: Number,
+        admin: Boolean,
+        canRemoveCustomTags: {
+            type: Boolean,
+            default: true
+        }
+    },
     computed: {
 
         /**
@@ -108,6 +112,8 @@ export default {
          */
         removeCustomTag (tag)
         {
+            if (!this.canRemoveCustomTags) return;
+
             this.$store.commit('removeCustomTag', {
                 photoId: this.photoId,
                 customTag: tag

--- a/resources/js/components/Modal/Photos/AddManyTagsToManyPhotos.vue
+++ b/resources/js/components/Modal/Photos/AddManyTagsToManyPhotos.vue
@@ -8,7 +8,7 @@
         <button
             :class="button"
             @click="submit"
-            :disabled="processing"
+            :disabled="checkTags"
         >{{ $t('common.submit') }}</button>
     </div>
 </template>
@@ -37,7 +37,17 @@ export default {
         button ()
         {
             return this.processing ? this.btn + ' is-loading' : this.btn;
-        }
+        },
+
+        /**
+         * Disable button if true
+         */
+        checkTags ()
+        {
+            if (this.processing) return true;
+
+            return Object.keys(this.$store.state.litter.tags[0] || {}).length === 0;
+        },
     },
     methods: {
 

--- a/resources/js/components/Modal/Photos/AddManyTagsToManyPhotos.vue
+++ b/resources/js/components/Modal/Photos/AddManyTagsToManyPhotos.vue
@@ -8,7 +8,7 @@
         <button
             :class="button"
             @click="submit"
-            :disabled="checkTags"
+            :disabled="!hasAddedTags"
         >{{ $t('common.submit') }}</button>
     </div>
 </template>
@@ -40,13 +40,18 @@ export default {
         },
 
         /**
-         * Disable button if true
+         * Disable button if false
          */
-        checkTags ()
+        hasAddedTags ()
         {
-            if (this.processing) return true;
+            if (this.processing) return false;
 
-            return Object.keys(this.$store.state.litter.tags[0] || {}).length === 0;
+            let tags = this.$store.state.litter.tags;
+            let customTags = this.$store.state.litter.customTags;
+            let hasTags = tags && tags[0] && Object.keys(tags[0]).length;
+            let hasCustomTags = customTags && customTags[0] && customTags[0].length;
+
+            return hasTags || hasCustomTags;
         },
     },
     methods: {

--- a/resources/js/store/modules/admin/actions.js
+++ b/resources/js/store/modules/admin/actions.js
@@ -95,7 +95,8 @@ export const actions = {
 
         await axios.post('/admin/update-tags', {
             photoId: photoId,
-            tags: context.rootState.litter.tags[photoId]
+            tags: context.rootState.litter.tags[photoId],
+            custom_tags: context.rootState.litter.customTags[photoId]
         })
         .then(response => {
             console.log('admin_verify_keep', response);

--- a/resources/js/store/modules/admin/actions.js
+++ b/resources/js/store/modules/admin/actions.js
@@ -138,6 +138,7 @@ export const actions = {
                 if (resp.data.photo?.verification > 0)
                 {
                     context.commit('initAdminItems', resp.data.photo);
+                    context.commit('initAdminCustomTags', resp.data.photo);
                 }
 
                 context.commit('initAdminMetadata', {

--- a/resources/js/store/modules/litter/actions.js
+++ b/resources/js/store/modules/litter/actions.js
@@ -16,7 +16,8 @@ export const actions = {
             inclIds: context.rootState.photos.inclIds,
             exclIds: context.rootState.photos.exclIds,
             filters: context.rootState.photos.filters,
-            tags: context.state.tags[0]
+            tags: context.state.tags[0],
+            custom_tags: context.state.customTags[0]
         })
         .then(response => {
             console.log('add_many_tags_to_many_photos', response);

--- a/resources/js/store/modules/litter/actions.js
+++ b/resources/js/store/modules/litter/actions.js
@@ -48,9 +48,10 @@ export const actions = {
         let photoId = context.rootState.photos.paginate.data[0].id;
 
         await axios.post('add-tags', {
+            photo_id: photoId,
             tags: context.state.tags[photoId],
+            custom_tags: context.state.customTags[photoId],
             presence: context.state.presence,
-            photo_id: photoId
         })
         .then(response => {
             /* improve this */

--- a/resources/js/store/modules/litter/init.js
+++ b/resources/js/store/modules/litter/init.js
@@ -8,6 +8,7 @@ export const init = {
     photos: {}, // paginated photos object
     tags: {}, // added tags go here -> { photoId: { smoking: { butts: 1, lighters: 2 }, alcohol: { beer_cans: 3 } }, ... };
     customTags: {},
+    customTagsError: '',
     submitting: false,
     recentTags: {},
     recentCustomTags: []

--- a/resources/js/store/modules/litter/init.js
+++ b/resources/js/store/modules/litter/init.js
@@ -3,9 +3,12 @@ export const init = {
     hasAddedNewTag: false, // Has the admin added a new tag yet? If FALSE, disable "Update With New Tags button"
     presence: null, // true = remaining
     tag: 'butts', // currently selected item
+    customTag: '', // currently selected custom tag
     loading: false,
     photos: {}, // paginated photos object
     tags: {}, // added tags go here -> { photoId: { smoking: { butts: 1, lighters: 2 }, alcohol: { beer_cans: 3 } }, ... };
+    customTags: {},
     submitting: false,
-    recentTags: {}
+    recentTags: {},
+    recentCustomTags: []
 };

--- a/resources/js/store/modules/litter/mutations.js
+++ b/resources/js/store/modules/litter/mutations.js
@@ -67,13 +67,19 @@ export const mutations = {
             tags[payload.photoId] = [];
         }
 
-        if (tags[payload.photoId].indexOf(payload.customTag) === -1 && tags[payload.photoId].length < 3) {
+        // Case-insensitive check for existing tags
+        if (tags[payload.photoId].find(tag => tag.toLowerCase() === payload.customTag.toLowerCase()) === undefined &&
+            tags[payload.photoId].length < 3
+        ) {
             tags[payload.photoId].push(payload.customTag);
 
             // Also add this tag to the recent custom tags
             if (state.recentCustomTags.indexOf(payload.customTag) === -1) {
                 state.recentCustomTags.push(payload.customTag);
             }
+
+            // And indicate that a new tag has been added
+            state.hasAddedNewTag = true; // Enable the Update Button
         }
 
         state.customTags = tags;
@@ -91,6 +97,8 @@ export const mutations = {
             state.tags = Object.assign({});
             state.customTags = Object.assign({});
         }
+
+        state.hasAddedNewTag = false; // Disable the Admin Update Button
     },
 
     /**
@@ -234,6 +242,7 @@ export const mutations = {
         tags[payload.photoId] = tags[payload.photoId].filter(tag => tag !== payload.customTag);
 
         state.customTags = tags;
+        state.hasAddedNewTag = true; // activate update_with_new_tags button
     },
 
     /**

--- a/resources/js/store/modules/litter/mutations.js
+++ b/resources/js/store/modules/litter/mutations.js
@@ -57,14 +57,39 @@ export const mutations = {
     },
 
     /**
+     * Add a Custom Tag to a photo.
+     */
+    addCustomTag (state, payload)
+    {
+        let tags = Object.assign({}, state.customTags);
+
+        if (!tags[payload.photoId]) {
+            tags[payload.photoId] = [];
+        }
+
+        if (tags[payload.photoId].indexOf(payload.customTag) === -1 && tags[payload.photoId].length < 3) {
+            tags[payload.photoId].push(payload.customTag);
+
+            // Also add this tag to the recent custom tags
+            if (state.recentCustomTags.indexOf(payload.customTag) === -1) {
+                state.recentCustomTags.push(payload.customTag);
+            }
+        }
+
+        state.customTags = tags;
+    },
+
+    /**
      * Clear the tags object (When we click next/previous image on pagination)
      */
     clearTags (state, photoId)
     {
         if (photoId !== null) {
             delete state.tags[photoId];
+            delete state.customTags[photoId];
         } else {
             state.tags = Object.assign({});
+            state.customTags = Object.assign({});
         }
     },
 
@@ -88,6 +113,14 @@ export const mutations = {
     changeTag (state, payload)
     {
         state.tag = payload;
+    },
+
+    /**
+     * Change the currently selected custom tag
+     */
+    changeCustomTag (state, payload)
+    {
+        state.customTag = payload;
     },
 
     /**
@@ -141,6 +174,14 @@ export const mutations = {
     },
 
     /**
+     * When AddTags is created, we check localStorage for the users recentCustomTags
+     */
+    initRecentCustomTags (state, payload)
+    {
+        state.recentCustomTags = payload;
+    },
+
+    /**
      * Remove a tag from a category
      * If category is empty, delete category
      */
@@ -170,6 +211,18 @@ export const mutations = {
 
         state.tags = tags;
         state.hasAddedNewTag = true; // activate update_with_new_tags button
+    },
+
+    /**
+     * Remove a custom tag
+     */
+    removeCustomTag (state, payload)
+    {
+        let tags = Object.assign({}, state.customTags);
+
+        tags[payload.photoId] = tags[payload.photoId].filter(tag => tag !== payload.customTag);
+
+        state.customTags = tags;
     },
 
     /**

--- a/resources/js/store/modules/litter/mutations.js
+++ b/resources/js/store/modules/litter/mutations.js
@@ -68,20 +68,29 @@ export const mutations = {
         }
 
         // Case-insensitive check for existing tags
-        if (tags[payload.photoId].find(tag => tag.toLowerCase() === payload.customTag.toLowerCase()) === undefined &&
-            tags[payload.photoId].length < 3
-        ) {
-            tags[payload.photoId].push(payload.customTag);
-
-            // Also add this tag to the recent custom tags
-            if (state.recentCustomTags.indexOf(payload.customTag) === -1) {
-                state.recentCustomTags.push(payload.customTag);
-            }
-
-            // And indicate that a new tag has been added
-            state.hasAddedNewTag = true; // Enable the Update Button
+        if (tags[payload.photoId].find(tag => tag.toLowerCase() === payload.customTag.toLowerCase()) !== undefined)
+        {
+            state.customTagsError = 'Tag already added.';
+            return;
         }
 
+        if (tags[payload.photoId].length >= 3)
+        {
+            state.customTagsError = 'You can upload up to 3 custom tags.';
+            return;
+        }
+
+        tags[payload.photoId].push(payload.customTag);
+
+        // Also add this tag to the recent custom tags
+        if (state.recentCustomTags.indexOf(payload.customTag) === -1)
+        {
+            state.recentCustomTags.push(payload.customTag);
+        }
+
+        // And indicate that a new tag has been added
+        state.hasAddedNewTag = true; // Enable the Update Button
+        state.customTagsError = ''; // Clear the error
         state.customTags = tags;
     },
 
@@ -129,6 +138,11 @@ export const mutations = {
     changeCustomTag (state, payload)
     {
         state.customTag = payload;
+    },
+
+    setCustomTagsError (state, payload)
+    {
+        state.customTagsError = payload;
     },
 
     /**

--- a/resources/js/store/modules/litter/mutations.js
+++ b/resources/js/store/modules/litter/mutations.js
@@ -157,6 +157,17 @@ export const mutations = {
     },
 
     /**
+     * Data from the user to verify
+     * map database column name to frontend string
+     */
+    initAdminCustomTags (state, payload)
+    {
+        state.customTags = {
+            [payload.id]: payload.custom_tags.map(t => t.tag)
+        };
+    },
+
+    /**
      * The users default presence of the litter they pick up
      * Some people leave it there, others usually pick it up
      */

--- a/resources/js/views/admin/VerifyPhotos.vue
+++ b/resources/js/views/admin/VerifyPhotos.vue
@@ -75,7 +75,7 @@
                             </div>
 
                             <div v-if="hasRecentTags" class="recent-tags control has-text-centered has-background-light py-4">
-                                <RecentTags class="mb-5" :photo-id="photo.id" />
+                                <RecentTags class="mb-5" :photo-id="photo.id" :show-custom-tags="false" />
                             </div>
                         </div>
 
@@ -94,7 +94,11 @@
                             </div>
 
                             <!-- Add / edit tags -->
-                            <add-tags :admin="true" :id="photo.id" />
+                            <div class="columns">
+                                <div class="column is-two-thirds is-offset-2">
+                                    <add-tags :admin="true" :id="photo.id" :show-custom-tags="false" />
+                                </div>
+                            </div>
 
                             <div style="padding-top: 1em; text-align: center;">
                                 <button :class="update_new_tags_button" @click="updateNewTags" :disabled="checkUpdateTagsDisabled">
@@ -114,9 +118,10 @@
 
                             <!-- The list of tags associated with this image-->
                             <Tags
-                            :photo-id="photo.id"
-                            :admin="true"
-                        />
+                                :photo-id="photo.id"
+                                :admin="true"
+                                :can-remove-custom-tags="false"
+                            />
 
                             <div style="padding-top: 3em;">
                                 <button class="button is-medium is-dark tooltip" @click="clearTags">

--- a/resources/js/views/admin/VerifyPhotos.vue
+++ b/resources/js/views/admin/VerifyPhotos.vue
@@ -75,7 +75,7 @@
                             </div>
 
                             <div v-if="hasRecentTags" class="recent-tags control has-text-centered has-background-light py-4">
-                                <RecentTags class="mb-5" :photo-id="photo.id" :show-custom-tags="false" />
+                                <RecentTags class="mb-5" :photo-id="photo.id" />
                             </div>
                         </div>
 
@@ -96,7 +96,7 @@
                             <!-- Add / edit tags -->
                             <div class="columns">
                                 <div class="column is-two-thirds is-offset-2">
-                                    <add-tags :admin="true" :id="photo.id" :show-custom-tags="false" />
+                                    <add-tags :admin="true" :id="photo.id" />
                                 </div>
                             </div>
 
@@ -120,7 +120,6 @@
                             <Tags
                                 :photo-id="photo.id"
                                 :admin="true"
-                                :can-remove-custom-tags="false"
                             />
 
                             <div style="padding-top: 3em;">

--- a/resources/js/views/admin/VerifyPhotos.vue
+++ b/resources/js/views/admin/VerifyPhotos.vue
@@ -289,8 +289,10 @@ export default {
         clearRecentTags ()
         {
             this.$store.commit('initRecentTags', {});
+            this.$store.commit('initRecentCustomTags', []);
 
             this.$localStorage.remove('recentTags');
+            this.$localStorage.remove('recentCustomTags');
         },
 
 		/**

--- a/resources/js/views/bbox/BoundingBox.vue
+++ b/resources/js/views/bbox/BoundingBox.vue
@@ -42,6 +42,7 @@
                         v-show="isAdmin"
                         :annotations="true"
                         :isVerifying="isVerifying"
+                        :show-custom-tags="false"
                     />
 
                 </div>

--- a/resources/js/views/general/Tag.vue
+++ b/resources/js/views/general/Tag.vue
@@ -190,7 +190,8 @@ export default {
          */
         hasRecentTags ()
         {
-            return Object.keys(this.$store.state.litter.recentTags).length > 0;
+            return Object.keys(this.$store.state.litter.recentTags).length > 0 ||
+                this.$store.state.litter.recentCustomTags.length > 0;
         },
 
         /**
@@ -251,8 +252,10 @@ export default {
         clearRecentTags ()
         {
             this.$store.commit('initRecentTags', {});
+            this.$store.commit('initRecentCustomTags', []);
 
             this.$localStorage.remove('recentTags');
+            this.$localStorage.remove('recentCustomTags');
         },
 
         /**

--- a/tests/Feature/Api/AddCustomTagsToPhotoTest.php
+++ b/tests/Feature/Api/AddCustomTagsToPhotoTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\User\User;
+use Illuminate\Support\Facades\Storage;
+use Tests\Feature\HasPhotoUploads;
+use Tests\TestCase;
+
+class AddCustomTagsToPhotoTest extends TestCase
+{
+    use HasPhotoUploads;
+
+    protected $imageAndAttributes;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('s3');
+        Storage::fake('bbox');
+
+        $this->setImagePath();
+
+        $this->imageAndAttributes = $this->getImageAndAttributes();
+    }
+
+    public function validationDataProvider(): array
+    {
+        return [
+            ['tags' => ['tag1', 'Tag1'], 'errors' => ['custom_tags.0', 'custom_tags.1']],// uniqueness
+            ['tags' => ['ta'], 'errors' => ['custom_tags.0']], // min length 3
+            ['tags' => [str_repeat('a', 101)], 'errors' => ['custom_tags.0']], // max length 100
+            ['tags' => ['tag1', 'tag2', 'tag3', 'tag4'], 'errors' => ['custom_tags']], // max 3 tags
+        ];
+    }
+
+    public function test_a_user_can_add_custom_tags_to_a_photo()
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $this->actingAs($user, 'api');
+        $this->post('/api/photos/submit', $this->getApiImageAttributes($this->imageAndAttributes));
+        $photo = $user->fresh()->photos->last();
+
+        $this->post('/api/add-tags', [
+            'photo_id' => $photo->id,
+            'tags' => ['smoking' => ['butts' => 3]],
+            'custom_tags' => ['tag1', 'tag2', 'tag3']
+        ])->assertOk();
+
+        $this->assertEquals(['tag1', 'tag2', 'tag3'], $photo->fresh()->customTags->pluck('tag')->toArray());
+    }
+
+    /**
+     * @dataProvider validationDataProvider
+     */
+    public function test_it_validates_the_custom_tags($tags, $errors)
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $this->actingAs($user, 'api');
+        $this->post('/api/photos/submit', $this->getApiImageAttributes($this->imageAndAttributes));
+        $photo = $user->fresh()->photos->last();
+
+        $response = $this->postJson('/api/add-tags', [
+            'photo_id' => $photo->id,
+            'tags' => ['smoking' => ['butts' => 3]],
+            'custom_tags' => $tags
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors($errors);
+        $this->assertCount(0, $photo->fresh()->customTags);
+    }
+}

--- a/tests/Feature/Api/AddCustomTagsToPhotoTest.php
+++ b/tests/Feature/Api/AddCustomTagsToPhotoTest.php
@@ -46,12 +46,11 @@ class AddCustomTagsToPhotoTest extends TestCase
 
         $this->post('/api/add-tags', [
             'photo_id' => $photo->id,
-            'tags' => ['smoking' => ['butts' => 3]],
             'custom_tags' => ['tag1', 'tag2', 'tag3']
         ])->assertOk();
 
         $this->assertEquals(['tag1', 'tag2', 'tag3'], $photo->fresh()->customTags->pluck('tag')->toArray());
-        $this->assertEquals(7, $user->fresh()->xp); // 1 + 3 + 3
+        $this->assertEquals(4, $user->fresh()->xp); // 1 + 3
     }
 
     /**
@@ -67,7 +66,6 @@ class AddCustomTagsToPhotoTest extends TestCase
 
         $response = $this->postJson('/api/add-tags', [
             'photo_id' => $photo->id,
-            'tags' => ['smoking' => ['butts' => 3]],
             'custom_tags' => $tags
         ]);
 

--- a/tests/Feature/Api/AddCustomTagsToPhotoTest.php
+++ b/tests/Feature/Api/AddCustomTagsToPhotoTest.php
@@ -42,6 +42,7 @@ class AddCustomTagsToPhotoTest extends TestCase
         $this->actingAs($user, 'api');
         $this->post('/api/photos/submit', $this->getApiImageAttributes($this->imageAndAttributes));
         $photo = $user->fresh()->photos->last();
+        $this->assertEquals(1, $user->fresh()->xp);
 
         $this->post('/api/add-tags', [
             'photo_id' => $photo->id,
@@ -50,6 +51,7 @@ class AddCustomTagsToPhotoTest extends TestCase
         ])->assertOk();
 
         $this->assertEquals(['tag1', 'tag2', 'tag3'], $photo->fresh()->customTags->pluck('tag')->toArray());
+        $this->assertEquals(7, $user->fresh()->xp); // 1 + 3 + 3
     }
 
     /**

--- a/tests/Feature/Api/UploadPhotoWithCustomTagsTest.php
+++ b/tests/Feature/Api/UploadPhotoWithCustomTagsTest.php
@@ -35,6 +35,7 @@ class UploadPhotoWithCustomTagsTest extends TestCase
         /** @var User $user */
         $user = User::factory()->create();
         $this->actingAs($user, 'api');
+        $this->assertEquals(0, $user->fresh()->xp);
 
         $response = $this->post('/api/photos/submit-with-tags', array_merge(
             $this->getApiImageAttributes($this->getImageAndAttributes()),
@@ -47,6 +48,7 @@ class UploadPhotoWithCustomTagsTest extends TestCase
             ['tag1', 'tag2', 'tag3'],
             $user->fresh()->photos->last()->customTags->pluck('tag')->toArray()
         );
+        $this->assertEquals(7, $user->fresh()->xp); // 1 + 3 + 3
     }
 
     /**

--- a/tests/Feature/Api/UploadPhotoWithCustomTagsTest.php
+++ b/tests/Feature/Api/UploadPhotoWithCustomTagsTest.php
@@ -39,7 +39,6 @@ class UploadPhotoWithCustomTagsTest extends TestCase
 
         $response = $this->post('/api/photos/submit-with-tags', array_merge(
             $this->getApiImageAttributes($this->getImageAndAttributes()),
-            ['tags' => json_encode(['smoking' => ['butts' => 3]])],
             ['custom_tags' => json_encode(['tag1', 'tag2', 'tag3'])]
         ));
 
@@ -48,7 +47,7 @@ class UploadPhotoWithCustomTagsTest extends TestCase
             ['tag1', 'tag2', 'tag3'],
             $user->fresh()->photos->last()->customTags->pluck('tag')->toArray()
         );
-        $this->assertEquals(7, $user->fresh()->xp); // 1 + 3 + 3
+        $this->assertEquals(4, $user->fresh()->xp); // 1 + 3
     }
 
     /**
@@ -62,7 +61,6 @@ class UploadPhotoWithCustomTagsTest extends TestCase
 
         $response = $this->postJson('/api/photos/submit-with-tags', array_merge(
             $this->getApiImageAttributes($this->getImageAndAttributes()),
-            ['tags' => json_encode(['smoking' => ['butts' => 3]])],
             ['custom_tags' => json_encode($tags)]
         ));
 

--- a/tests/Feature/Api/UploadPhotoWithCustomTagsTest.php
+++ b/tests/Feature/Api/UploadPhotoWithCustomTagsTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\User\User;
+use Illuminate\Support\Facades\Storage;
+use Tests\Feature\HasPhotoUploads;
+use Tests\TestCase;
+
+class UploadPhotoWithCustomTagsTest extends TestCase
+{
+    use HasPhotoUploads;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('s3');
+        Storage::fake('bbox');
+        $this->setImagePath();
+    }
+
+    public function validationDataProvider(): array
+    {
+        return [
+            ['tags' => ['tag1', 'Tag1'], 'errors' => ['custom_tags.0', 'custom_tags.1']],// uniqueness
+            ['tags' => ['ta'], 'errors' => ['custom_tags.0']], // min length 3
+            ['tags' => [str_repeat('a', 101)], 'errors' => ['custom_tags.0']], // max length 100
+            ['tags' => ['tag1', 'tag2', 'tag3', 'tag4'], 'errors' => ['custom_tags']], // max 3 tags
+        ];
+    }
+
+    public function test_an_api_user_can_upload_a_photo_with_custom_tags()
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $this->actingAs($user, 'api');
+
+        $response = $this->post('/api/photos/submit-with-tags', array_merge(
+            $this->getApiImageAttributes($this->getImageAndAttributes()),
+            ['tags' => json_encode(['smoking' => ['butts' => 3]])],
+            ['custom_tags' => json_encode(['tag1', 'tag2', 'tag3'])]
+        ));
+
+        $response->assertOk()->assertJson(['success' => true]);
+        $this->assertEquals(
+            ['tag1', 'tag2', 'tag3'],
+            $user->fresh()->photos->last()->customTags->pluck('tag')->toArray()
+        );
+    }
+
+    /**
+     * @dataProvider validationDataProvider
+     */
+    public function test_it_validates_the_custom_tags($tags, $errors)
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $this->actingAs($user, 'api');
+
+        $response = $this->postJson('/api/photos/submit-with-tags', array_merge(
+            $this->getApiImageAttributes($this->getImageAndAttributes()),
+            ['tags' => json_encode(['smoking' => ['butts' => 3]])],
+            ['custom_tags' => json_encode($tags)]
+        ));
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors($errors);
+        $this->assertCount(0, $user->fresh()->photos);
+    }
+}

--- a/tests/Feature/Photos/AddCustomTagsToPhotoTest.php
+++ b/tests/Feature/Photos/AddCustomTagsToPhotoTest.php
@@ -40,6 +40,7 @@ class AddCustomTagsToPhotoTest extends TestCase
         $user = User::factory()->create();
         $this->actingAs($user)->post('/submit', ['file' => $this->imageAndAttributes['file'],]);
         $photo = $user->fresh()->photos->last();
+        $this->assertEquals(1, $user->fresh()->xp);
 
         $this->post('/add-tags', [
             'photo_id' => $photo->id,
@@ -49,6 +50,7 @@ class AddCustomTagsToPhotoTest extends TestCase
         ])->assertOk();
 
         $this->assertEquals(['tag1', 'tag2', 'tag3'], $photo->fresh()->customTags->pluck('tag')->toArray());
+        $this->assertEquals(7, $user->fresh()->xp); // 1 + 3 + 3
     }
 
     /**

--- a/tests/Feature/Photos/AddCustomTagsToPhotoTest.php
+++ b/tests/Feature/Photos/AddCustomTagsToPhotoTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature\Photos;
+
+use App\Models\User\User;
+use Illuminate\Support\Facades\Storage;
+use Tests\Feature\HasPhotoUploads;
+use Tests\TestCase;
+
+class AddCustomTagsToPhotoTest extends TestCase
+{
+    use HasPhotoUploads;
+
+    protected $imageAndAttributes;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('s3');
+        Storage::fake('bbox');
+
+        $this->setImagePath();
+
+        $this->imageAndAttributes = $this->getImageAndAttributes();
+    }
+
+    public function validationDataProvider(): array
+    {
+        return [
+            ['tags' => ['tag1', 'Tag1'], 'errors' => ['custom_tags.0', 'custom_tags.1']],// uniqueness
+            ['tags' => ['ta'], 'errors' => ['custom_tags.0']], // min length 3
+            ['tags' => [str_repeat('a', 101)], 'errors' => ['custom_tags.0']], // max length 100
+            ['tags' => ['tag1', 'tag2', 'tag3', 'tag4'], 'errors' => ['custom_tags']], // max 3 tags
+        ];
+    }
+
+    public function test_a_user_can_add_custom_tags_to_a_photo()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user)->post('/submit', ['file' => $this->imageAndAttributes['file'],]);
+        $photo = $user->fresh()->photos->last();
+
+        $this->post('/add-tags', [
+            'photo_id' => $photo->id,
+            'presence' => true,
+            'tags' => ['smoking' => ['butts' => 3]],
+            'custom_tags' => ['tag1', 'tag2', 'tag3']
+        ])->assertOk();
+
+        $this->assertEquals(['tag1', 'tag2', 'tag3'], $photo->fresh()->customTags->pluck('tag')->toArray());
+    }
+
+    /**
+     * @dataProvider validationDataProvider
+     */
+    public function test_it_validates_the_custom_tags($tags, $errors)
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user)->post('/submit', ['file' => $this->imageAndAttributes['file'],]);
+        $photo = $user->fresh()->photos->last();
+
+        $response = $this->postJson('/add-tags', [
+            'photo_id' => $photo->id,
+            'presence' => true,
+            'tags' => ['smoking' => ['butts' => 3]],
+            'custom_tags' => $tags
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors($errors);
+        $this->assertCount(0, $photo->fresh()->customTags);
+    }
+}

--- a/tests/Feature/Photos/AddCustomTagsToPhotoTest.php
+++ b/tests/Feature/Photos/AddCustomTagsToPhotoTest.php
@@ -42,15 +42,14 @@ class AddCustomTagsToPhotoTest extends TestCase
         $photo = $user->fresh()->photos->last();
         $this->assertEquals(1, $user->fresh()->xp);
 
-        $this->post('/add-tags', [
+        $this->postJson('/add-tags', [
             'photo_id' => $photo->id,
             'presence' => true,
-            'tags' => ['smoking' => ['butts' => 3]],
             'custom_tags' => ['tag1', 'tag2', 'tag3']
         ])->assertOk();
 
         $this->assertEquals(['tag1', 'tag2', 'tag3'], $photo->fresh()->customTags->pluck('tag')->toArray());
-        $this->assertEquals(7, $user->fresh()->xp); // 1 + 3 + 3
+        $this->assertEquals(4, $user->fresh()->xp); // 1 + 3
     }
 
     /**
@@ -65,7 +64,6 @@ class AddCustomTagsToPhotoTest extends TestCase
         $response = $this->postJson('/add-tags', [
             'photo_id' => $photo->id,
             'presence' => true,
-            'tags' => ['smoking' => ['butts' => 3]],
             'custom_tags' => $tags
         ]);
 

--- a/tests/Feature/Photos/AddManyTagsToManyPhotosTest.php
+++ b/tests/Feature/Photos/AddManyTagsToManyPhotosTest.php
@@ -11,12 +11,13 @@ class AddManyTagsToManyPhotosTest extends TestCase
     public function test_a_user_can_add_custom_tags_to_a_photo()
     {
         /** @var User $user */
-        $user = User::factory()->create();
+        $user = User::factory()->create(['xp' => 2]);
         $photos = Photo::factory(2)->create([
             'user_id' => $user->id,
             'verified' => 0,
             'verification' => 0
         ]);
+        $this->assertEquals(2, $user->fresh()->xp);
 
         $response = $this->actingAs($user)->postJson('/user/profile/photos/tags/create', [
             'selectAll' => false,
@@ -30,6 +31,7 @@ class AddManyTagsToManyPhotosTest extends TestCase
         $response->assertJson(['success' => true]);
         foreach ($photos as $photo) {
             $this->assertEquals(['tag1', 'tag2', 'tag3'], $photo->fresh()->customTags->pluck('tag')->toArray());
-        };
+        }
+        $this->assertEquals(14, $user->fresh()->xp); // 2 + (6 + 6)
     }
 }

--- a/tests/Feature/Photos/AddManyTagsToManyPhotosTest.php
+++ b/tests/Feature/Photos/AddManyTagsToManyPhotosTest.php
@@ -2,13 +2,67 @@
 
 namespace Tests\Feature\Photos;
 
+use App\Models\Litter\Categories\Smoking;
 use App\Models\Photo;
 use App\Models\User\User;
 use Tests\TestCase;
 
 class AddManyTagsToManyPhotosTest extends TestCase
 {
+    public function test_a_user_can_add_tags_to_a_photo()
+    {
+        /** @var User $user */
+        $user = User::factory()->create(['xp' => 2]);
+        $photos = Photo::factory(2)->create([
+            'user_id' => $user->id,
+            'verified' => 0,
+            'verification' => 0
+        ]);
+        $this->assertEquals(2, $user->fresh()->xp);
+
+        $response = $this->actingAs($user)->postJson('/user/profile/photos/tags/create', [
+            'selectAll' => false,
+            'filters' => [],
+            'inclIds' => $photos->pluck('id')->toArray(),
+            'tags' => ['smoking' => ['butts' => 3]],
+        ]);
+
+        $response->assertOk();
+        $response->assertJson(['success' => true]);
+        foreach ($photos as $photo) {
+            $this->assertInstanceOf(Smoking::class, $photo->fresh()->smoking);
+            $this->assertEquals(3, $photo->fresh()->smoking->butts);
+        }
+        $this->assertEquals(8, $user->fresh()->xp); // 2 + 6
+    }
+
     public function test_a_user_can_add_custom_tags_to_a_photo()
+    {
+        /** @var User $user */
+        $user = User::factory()->create(['xp' => 2]);
+        $photos = Photo::factory(2)->create([
+            'user_id' => $user->id,
+            'verified' => 0,
+            'verification' => 0
+        ]);
+        $this->assertEquals(2, $user->fresh()->xp);
+
+        $response = $this->actingAs($user)->postJson('/user/profile/photos/tags/create', [
+            'selectAll' => false,
+            'filters' => [],
+            'inclIds' => $photos->pluck('id')->toArray(),
+            'custom_tags' => ['tag1', 'tag2', 'tag3']
+        ]);
+
+        $response->assertOk();
+        $response->assertJson(['success' => true]);
+        foreach ($photos as $photo) {
+            $this->assertEquals(['tag1', 'tag2', 'tag3'], $photo->fresh()->customTags->pluck('tag')->toArray());
+        }
+        $this->assertEquals(8, $user->fresh()->xp); // 2 + 8
+    }
+
+    public function test_a_user_can_add_tags_and_custom_tags_to_a_photo()
     {
         /** @var User $user */
         $user = User::factory()->create(['xp' => 2]);
@@ -30,6 +84,8 @@ class AddManyTagsToManyPhotosTest extends TestCase
         $response->assertOk();
         $response->assertJson(['success' => true]);
         foreach ($photos as $photo) {
+            $this->assertInstanceOf(Smoking::class, $photo->fresh()->smoking);
+            $this->assertEquals(3, $photo->fresh()->smoking->butts);
             $this->assertEquals(['tag1', 'tag2', 'tag3'], $photo->fresh()->customTags->pluck('tag')->toArray());
         }
         $this->assertEquals(14, $user->fresh()->xp); // 2 + (6 + 6)

--- a/tests/Feature/Photos/AddManyTagsToManyPhotosTest.php
+++ b/tests/Feature/Photos/AddManyTagsToManyPhotosTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature\Photos;
+
+use App\Models\Photo;
+use App\Models\User\User;
+use Tests\TestCase;
+
+class AddManyTagsToManyPhotosTest extends TestCase
+{
+    public function test_a_user_can_add_custom_tags_to_a_photo()
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $photos = Photo::factory(2)->create([
+            'user_id' => $user->id,
+            'verified' => 0,
+            'verification' => 0
+        ]);
+
+        $response = $this->actingAs($user)->postJson('/user/profile/photos/tags/create', [
+            'selectAll' => false,
+            'filters' => [],
+            'inclIds' => $photos->pluck('id')->toArray(),
+            'tags' => ['smoking' => ['butts' => 3]],
+            'custom_tags' => ['tag1', 'tag2', 'tag3']
+        ]);
+
+        $response->assertOk();
+        $response->assertJson(['success' => true]);
+        foreach ($photos as $photo) {
+            $this->assertEquals(['tag1', 'tag2', 'tag3'], $photo->fresh()->customTags->pluck('tag')->toArray());
+        };
+    }
+}

--- a/tests/Unit/Actions/Photos/DeleteTagsFromPhotoActionTest.php
+++ b/tests/Unit/Actions/Photos/DeleteTagsFromPhotoActionTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Actions\Photos;
 
+use App\Actions\Photos\AddCustomTagsToPhotoAction;
 use App\Actions\Photos\AddTagsToPhotoAction;
 use App\Actions\Photos\DeleteTagsFromPhotoAction;
 use App\Models\Photo;
@@ -9,7 +10,31 @@ use Tests\TestCase;
 
 class DeleteTagsFromPhotoActionTest extends TestCase
 {
-    public function test_it_returns_the_correct_number_of_deleted_litter_and_brands()
+    public function test_it_deletes_the_tags()
+    {
+        /** @var Photo $photo */
+        $photo = Photo::factory()->create();
+        /** @var AddTagsToPhotoAction $addTagsAction */
+        $addTagsAction = app(AddTagsToPhotoAction::class);
+        $addTagsAction->run($photo, [
+            'brands' => ['adidas' => 5],
+            'art' => ['item' => 2]
+        ]);
+        /** @var AddCustomTagsToPhotoAction $addTagsAction */
+        $addTagsAction = app(AddCustomTagsToPhotoAction::class);
+        $addTagsAction->run($photo, ['tag1', 'tag2', 'tag3']);
+
+        /** @var DeleteTagsFromPhotoAction $deleteTagsAction */
+        $deleteTagsAction = app(DeleteTagsFromPhotoAction::class);
+        $deleteTagsAction->run($photo->fresh());
+
+        $photo->refresh();
+        $this->assertNull($photo->brands);
+        $this->assertNull($photo->art);
+        $this->assertEmpty($photo->customTags);
+    }
+
+    public function test_it_returns_the_correct_number_of_deleted_litter_brands_and_custom_tags()
     {
         /** @var Photo $photo */
         $photo = Photo::factory()->create();
@@ -17,20 +42,19 @@ class DeleteTagsFromPhotoActionTest extends TestCase
         /** @var AddTagsToPhotoAction $addTagsAction */
         $addTagsAction = app(AddTagsToPhotoAction::class);
         $addTagsAction->run($photo, [
-            'brands' => [
-                'adidas' => 5
-            ],
-            'art' => [
-                'item' => 2
-            ]
+            'brands' => ['adidas' => 5],
+            'art' => ['item' => 2]
         ]);
+        /** @var AddCustomTagsToPhotoAction $addTagsAction */
+        $addTagsAction = app(AddCustomTagsToPhotoAction::class);
+        $addTagsAction->run($photo, ['tag1', 'tag2', 'tag3']);
 
         /** @var DeleteTagsFromPhotoAction $deleteTagsAction */
         $deleteTagsAction = app(DeleteTagsFromPhotoAction::class);
         $deletedTags = $deleteTagsAction->run($photo->fresh());
 
         $this->assertEquals(
-            ['all' => 7, 'litter' => 2, 'brands' => 5],
+            ['all' => 10, 'litter' => 2, 'brands' => 5, 'custom' => 3],
             $deletedTags
         );
     }

--- a/tests/Unit/Commands/UpdateRedisLocationsXpTest.php
+++ b/tests/Unit/Commands/UpdateRedisLocationsXpTest.php
@@ -25,6 +25,7 @@ class UpdateRedisLocationsXpTest extends TestCase
             'state_id' => $state1->id,
             'city_id' => $city1->id
         ]);
+        /** @var Photo $photo2 */
         $photo2 = Photo::factory()->create([
             'user_id' => $user->id,
             'smoking_id' => Smoking::factory()->create(['butts' => 5])->id,
@@ -32,6 +33,7 @@ class UpdateRedisLocationsXpTest extends TestCase
             'state_id' => $state2->id,
             'city_id' => $city2->id
         ]);
+        $photo2->customTags()->create(['tag' => 'custom tag example']);
         Redis::del("xp.users");
         $this->clearRedisLocation($country1, $state1, $city1);
         $this->clearRedisLocation($country2, $state2, $city2);
@@ -41,9 +43,9 @@ class UpdateRedisLocationsXpTest extends TestCase
 
         $this->artisan('users:update-redis-locations-xp');
 
-        $this->assertEquals(10, Redis::zscore("xp.users", $user->id));
+        $this->assertEquals(11, Redis::zscore("xp.users", $user->id));
         $this->assertRedisLocationEquals(4, $user, $country1, $state1, $city1);
-        $this->assertRedisLocationEquals(6, $user, $country2, $state2, $city2);
+        $this->assertRedisLocationEquals(7, $user, $country2, $state2, $city2);
     }
 
     private function createLocation(): array

--- a/tests/Unit/Exports/CreateCSVExportTest.php
+++ b/tests/Unit/Exports/CreateCSVExportTest.php
@@ -11,18 +11,14 @@ class CreateCSVExportTest extends TestCase
 {
     public function test_it_has_correct_headings_for_all_categories_and_tags()
     {
-        $expected = [
-            'id', 'verification', 'phone', 'datetime', 'lat', 'lon', 'picked up', 'address', 'total_litter'
-        ];
-
+        $expected = ['id', 'verification', 'phone', 'datetime', 'lat', 'lon', 'picked up', 'address', 'total_litter'];
         foreach (Photo::categories() as $category) {
             $photo = Photo::factory()->make();
             $types = $photo->$category()->make()->types();
-
             $expected[] = strtoupper($category);
             $expected = array_merge($expected, $types);
         }
-
+        $expected = array_merge($expected, ['custom_tag_1', 'custom_tag_2', 'custom_tag_3']);
         // We make this assertion to be sure that
         // the exporter does not persist extra models
         $this->assertDatabaseCount('photos', 0);
@@ -30,7 +26,6 @@ class CreateCSVExportTest extends TestCase
         $export = new CreateCSVExport('null', 1, null, null);
 
         $this->assertEquals($expected, $export->headings());
-
         $this->assertDatabaseCount('photos', 0);
     }
 
@@ -47,7 +42,7 @@ class CreateCSVExportTest extends TestCase
             'display_name' => '12345 Street',
             'total_litter' => 500
         ]);
-
+        $photo->customTags()->createMany([['tag' => 'tag 1'], ['tag' => 'tag 2'], ['tag' => 'tag 3']]);
         $expected = [
             $photo->id,
             $photo->verified,
@@ -59,7 +54,6 @@ class CreateCSVExportTest extends TestCase
             $photo->display_name,
             $photo->total_litter,
         ];
-
         foreach (Photo::categories() as $category) {
             $model = $this->createCategoryWithTags($photo, $category);
 
@@ -70,7 +64,7 @@ class CreateCSVExportTest extends TestCase
                 $expected[] = $model->$type;
             }
         }
-
+        $expected = array_merge($expected, ['tag 1', 'tag 2', 'tag 3']);
         // We make this assertion to be sure that
         // the exporter does not persist extra models
         $this->assertDatabaseCount('photos', 1);
@@ -78,7 +72,6 @@ class CreateCSVExportTest extends TestCase
         $export = new CreateCSVExport('null', 1, null, null);
 
         $this->assertEquals($expected, $export->map($photo->fresh()));
-
         $this->assertDatabaseCount('photos', 1);
     }
 


### PR DESCRIPTION
https://trello.com/c/sdBofxbl

This PR adds support for adding multiple custom tags from users.
- Custom tags are not grouped into categories.
- A user can upload up to 3 custom tags per photo, and each tag should be between 3-100 characters, and unique (case insensitive).
- A user can submit a photo even with only custom tags, they don't need to select a usual tag. Custom tags count toward XP, 1 tag = 1 XP, we also update the Redis Leaderboards.
- Custom tags are shown on the Tagging page together with the usual tags, and the recent tags. Custom tags for a photo are preserved when switching back and forth from photos.
- We also show the custom tags on the Admin Verify Photos page, and we allow modifying them. Also, an admin can use custom tags to tag users' photos. We don't show custom tags on the Bounding Box page at all.
- We also allow users to add custom tags to many photos, on their profile page. It's not required to submit a usual tag to the photos.
- We provide the custom tags data in the excel downloads. At the end of every row, we show three new columns: 'custom_tag_1', 'custom_tag_2', 'custom_tag_3', which contain the tags of the photo, they're not quantities, just the text.
- There is support for custom tags on the API side, using the same requests as the 'Upload with Tags', or 'Add tags' routes, the key is 'custom_tags', and it should be an array of strings. (If you can't send an array, send a JSON string of the array instead, just like with usual tags).

To do:
- Translations


![Screenshot 2022-02-06 193234](https://user-images.githubusercontent.com/29065651/152695904-9bab21d4-bffe-44ca-a86b-79a3b272e760.png)
