### PR TITLE
Fixed litter art text in the Global Map

### DIFF
--- a/app/Console/Commands/CompileResultsString.php
+++ b/app/Console/Commands/CompileResultsString.php
@@ -43,14 +43,11 @@ class CompileResultsString extends Command
      */
     public function handle()
     {
-        $photos = Photo::where('verified', '>', 0)->get();
-
-        foreach ($photos as $photo)
-        {
-            if (is_null($photo->result_string))
-            {
-                $photo->translate();
-            }
-        }
+        Photo::query()
+            ->where('verified', '>', 0)
+            ->whereNull('result_string')
+            ->get()
+            ->each
+            ->translate();
     }
 }

--- a/resources/js/langs/en/litter.json
+++ b/resources/js/langs/en/litter.json
@@ -42,7 +42,7 @@
         "alcoholOther": "Alcohol-Other"
     },
     "art": {
-        "item": "Item"
+        "item": "Litter Art"
     },
     "coffee": {
         "coffeeCups": "Coffee Cups",

--- a/resources/js/langs/es/litter.json
+++ b/resources/js/langs/es/litter.json
@@ -42,7 +42,7 @@
         "alcoholOther": "Alcohol-Otros"
     },
     "art": {
-        "item": "Articulo"
+        "item": "Arte de la Basura"
     },
     "coffee": {
         "coffeeCups": "Vasos de café",

--- a/resources/js/langs/nl/litter.json
+++ b/resources/js/langs/nl/litter.json
@@ -42,7 +42,7 @@
         "alcoholOther": "Alcohol-Overig"
     },
     "art": {
-        "item": "Item"
+        "item": "Zwerfvuil"
     },
     "coffee": {
         "coffeeCups": "Koffie Bekers",

--- a/resources/js/langs/pl/litter.json
+++ b/resources/js/langs/pl/litter.json
@@ -42,7 +42,7 @@
         "alcoholOther": "Akohol (inne)"
     },
     "art": {
-        "item": "Pozycja"
+        "item": "Sztuka Miotu"
     },
     "coffee": {
         "coffeeCups": "Kubeczek po kawie",

--- a/resources/js/langs/pt/litter.json
+++ b/resources/js/langs/pt/litter.json
@@ -42,7 +42,7 @@
         "alcoholOther": "Álcool-Outros"
     },
     "art": {
-        "item": "Item"
+        "item": "Arte de Lixo"
     },
     "coffee": {
         "coffeeCups": "Xícaras de café",

--- a/resources/js/maps/mapHelpers.js
+++ b/resources/js/maps/mapHelpers.js
@@ -32,7 +32,11 @@ const helper = {
         a.forEach(i => {
             let b = i.split(' ');
 
-            tags += i18n.t('litter.' + b[0]) + ': ' + b[1] + '<br>';
+            if (b[0] === 'art.item') {
+                tags += i18n.t('litter.' + b[0]) + '<br>';
+            } else {
+                tags += i18n.t('litter.' + b[0]) + ': ' + b[1] + '<br>';
+            }
         });
 
         return tags;

--- a/resources/js/views/global/Supercluster.vue
+++ b/resources/js/views/global/Supercluster.vue
@@ -190,7 +190,7 @@ function onEachArtFeature (feature, layer)
             .setContent(
                 mapHelper.getMapImagePopupContent(
                     feature.properties.filename,
-                    null,
+                    feature.properties.result_string,
                     feature.properties.datetime,
                     feature.properties.picked_up,
                     user,


### PR DESCRIPTION
https://trello.com/c/velI39D4

We simply didn't pass the art items `result_string` to the rendering method. We pass it now.
I changed the text to read 'Litter Art', without the quantity of 1.

I refactored the command that generates the result string when an image is tagged. We could improve further by compiling the result string of only the photo being tagged, but that's for another time.

![image](https://user-images.githubusercontent.com/29065651/153031998-5bcabe72-049b-491a-9bcb-e06104012d56.png)
