### PR TITLE
Small bug fix on community page

### DIFF
--- a/app/Http/Controllers/CommunityController.php
+++ b/app/Http/Controllers/CommunityController.php
@@ -56,7 +56,6 @@ class CommunityController extends Controller
                 count(id) as total,
                 date_format(created_at, '%b %Y') as period
             ")
-            ->orderBy('created_at')
             ->groupBy('period')
             ->get()
             ->keyBy('period');
@@ -66,7 +65,6 @@ class CommunityController extends Controller
                 count(id) as total,
                 date_format(created_at, '%b %Y') as period
             ")
-            ->orderBy('created_at')
             ->groupBy('period')
             ->get()
             ->keyBy('period');


### PR DESCRIPTION
We don't need to sort the items at all in the query since we ignore the order anyway.