### PR TITLE
Bugfix - Fix picked up on global map

### DIFF
--- a/app/Console/Commands/Clusters/GenerateClusters.php
+++ b/app/Console/Commands/Clusters/GenerateClusters.php
@@ -159,9 +159,9 @@ class GenerateClusters extends Command
      */
     private function getYearsWithNewPhotos(): array
     {
-        $yearsWithData = [null];
-
+        $yearsWithData = [];
         $years = range(2017, now()->year);
+
         foreach ($years as $year) {
             $hasRecentPhotosForYear = Photo::query()->where([
                 ['created_at', '>=', now()->subDay()->startOfDay()],
@@ -175,6 +175,8 @@ class GenerateClusters extends Command
             }
         }
 
-        return $yearsWithData;
+        return empty($yearsWithData)
+            ? []
+            : array_merge([null], $yearsWithData);
     }
 }

--- a/app/Http/Controllers/CommunityController.php
+++ b/app/Http/Controllers/CommunityController.php
@@ -56,6 +56,7 @@ class CommunityController extends Controller
                 count(id) as total,
                 date_format(created_at, '%b %Y') as period
             ")
+            ->whereYear('created_at', '>=', 2020)
             ->groupBy('period')
             ->get()
             ->keyBy('period');
@@ -65,12 +66,13 @@ class CommunityController extends Controller
                 count(id) as total,
                 date_format(created_at, '%b %Y') as period
             ")
+            ->whereYear('created_at', '>=', 2020)
             ->groupBy('period')
             ->get()
             ->keyBy('period');
 
         $periods = [];
-        foreach (CarbonPeriod::create('2020-01-01', '1 month', now()) as $period) {
+        foreach (CarbonPeriod::create('2020-01-01', '1 month', now()->subMonth()) as $period) {
             $periods[] = $period->format('M Y');
         }
 

--- a/app/Http/Controllers/GlobalMap/GlobalMapController.php
+++ b/app/Http/Controllers/GlobalMap/GlobalMapController.php
@@ -60,6 +60,7 @@ class GlobalMapController extends Controller
                 'geohash',
                 'lat',
                 'lon',
+                'remaining',
                 'datetime'
             )
             ->with([

--- a/app/Http/Controllers/PhotosController.php
+++ b/app/Http/Controllers/PhotosController.php
@@ -333,7 +333,7 @@ class PhotosController extends Controller
 
         $this->updateLeaderboardsAction->run($photo, $user->id, $litterTotals['all'] + $customTagsTotal);
 
-        $photo->remaining = !$request->presence;
+        $photo->remaining = !$request->picked_up;
         $photo->total_litter = $litterTotals['litter'];
 
         if (!$user->is_trusted)

--- a/app/Http/Controllers/Teams/TeamsClusterController.php
+++ b/app/Http/Controllers/Teams/TeamsClusterController.php
@@ -66,6 +66,7 @@ class TeamsClusterController extends Controller
                 'geohash',
                 'lat',
                 'lon',
+                'remaining',
                 'datetime'
             )
             ->with([

--- a/app/Http/Requests/AddTagsRequest.php
+++ b/app/Http/Requests/AddTagsRequest.php
@@ -16,7 +16,7 @@ class AddTagsRequest extends FormRequest
         return [
             'photo_id' => 'required|exists:photos,id',
             'tags' => 'required_without:custom_tags|array',
-            'presence' => 'required|boolean',
+            'picked_up' => 'required|boolean',
             'custom_tags' => 'required_without:tags|array|max:3',
             'custom_tags.*' => 'distinct:ignore_case|min:3|max:100'
         ];

--- a/database/migrations/2022_03_03_140223_add_created_at_indexes.php
+++ b/database/migrations/2022_03_03_140223_add_created_at_indexes.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddCreatedAtIndexes extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('photos', function (Blueprint $table) {
+            $table->index('created_at');
+        });
+        Schema::table('users', function (Blueprint $table) {
+            $table->index('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}

--- a/resources/js/components/Litter/AddTags.vue
+++ b/resources/js/components/Litter/AddTags.vue
@@ -326,14 +326,6 @@ export default {
         },
 
         /**
-         * Has the litter been picked up, or is it still there?
-         */
-        presence ()
-        {
-            return this.$store.state.litter.presence;
-        },
-
-        /**
          * The most recent tags the user has applied
          */
         recentTags ()

--- a/resources/js/components/Litter/Presence.vue
+++ b/resources/js/components/Litter/Presence.vue
@@ -1,10 +1,9 @@
 <template>
     <div class="expand-mobile">
-        <strong :style="{ color: remaining ? 'green' : 'red' }"><slot>{{ remainingText }}</slot></strong>
+        <strong :style="{ color: pickedUp ? 'green' : 'red' }"><slot>{{ pickedUpText }}</slot></strong>
         <br>
         <button :class="toggle_class" @click="toggle">
-            <slot v-if="remaining">{{ $t('litter.presence.still-there') }}</slot>
-
+            <slot v-if="pickedUp">{{ $t('litter.presence.still-there') }}</slot>
             <slot v-else>{{ $t('litter.presence.picked-up') }}</slot>
         </button>
     </div>
@@ -18,17 +17,17 @@ export default {
         /**
          * Change setting name to "picked_up"
          */
-        remaining ()
+        pickedUp ()
         {
-            return this.$store.state.litter.presence;
+            return this.$store.state.litter.pickedUp;
         },
 
         /**
          *
          */
-        remainingText ()
+        pickedUpText ()
         {
-            return this.$store.state.litter.presence ? this.$t('litter.presence.picked-up-text') : this.$t('litter.presence.still-there-text');
+            return this.pickedUp ? this.$t('litter.presence.picked-up-text') : this.$t('litter.presence.still-there-text');
         },
 
         /**
@@ -36,17 +35,17 @@ export default {
          */
         toggle_class ()
         {
-            return this.remaining ? 'button is-danger' : 'button is-success';
+            return this.pickedUp ? 'button is-danger' : 'button is-success';
         }
     },
     methods: {
 
         /**
-         * Toggle the presense of the litter
+         * Toggle the presence of the litter
          */
         toggle ()
         {
-            this.$store.commit('togglePresence');
+            this.$store.commit('togglePickedUp');
         }
     }
 }

--- a/resources/js/store/modules/litter/actions.js
+++ b/resources/js/store/modules/litter/actions.js
@@ -52,7 +52,7 @@ export const actions = {
             photo_id: photoId,
             tags: context.state.tags[photoId],
             custom_tags: context.state.customTags[photoId],
-            presence: context.state.presence,
+            picked_up: context.state.pickedUp,
         })
         .then(response => {
             /* improve this */

--- a/resources/js/store/modules/litter/init.js
+++ b/resources/js/store/modules/litter/init.js
@@ -1,7 +1,7 @@
 export const init = {
     category: 'smoking', // currently selected category.
     hasAddedNewTag: false, // Has the admin added a new tag yet? If FALSE, disable "Update With New Tags button"
-    presence: null, // true = remaining
+    pickedUp: null, // true = picked up
     tag: 'butts', // currently selected item
     customTag: '', // currently selected custom tag
     loading: false,

--- a/resources/js/store/modules/litter/mutations.js
+++ b/resources/js/store/modules/litter/mutations.js
@@ -191,15 +191,6 @@ export const mutations = {
     },
 
     /**
-     * The users default presence of the litter they pick up
-     * Some people leave it there, others usually pick it up
-     */
-    initPresence (state, payload)
-    {
-        state.presence = payload;
-    },
-
-    /**
      * When AddTags is created, we check localStorage for the users recentTags
      */
     initRecentTags (state, payload)
@@ -322,11 +313,11 @@ export const mutations = {
 
     /**
      * When the user object is created (page refresh or login), we set the users default presence value here
-     * Presence = Is the litter picked up, or is it still there
+     * If the litter is picked up, this value will be 'true'
      */
-    set_default_litter_presence (state, payload)
+    set_default_litter_picked_up (state, payload)
     {
-        state.presence = payload;
+        state.pickedUp = payload;
     },
 
     /**
@@ -343,9 +334,9 @@ export const mutations = {
     /**
      *
      */
-    togglePresence (state)
+    togglePickedUp (state)
     {
-        state.presence = !state.presence;
+        state.pickedUp = !state.pickedUp;
     },
     /**
      *

--- a/resources/js/store/modules/photos/mutations.js
+++ b/resources/js/store/modules/photos/mutations.js
@@ -53,7 +53,7 @@ export const mutations = {
     photosForTagging (state, payload)
     {
         state.paginate = payload.photos;
-        state.remaining = payload.remaining;
+        state.pickedUp = payload.picked_up;
         state.total = payload.total;
     },
 

--- a/resources/js/store/modules/user/actions.js
+++ b/resources/js/store/modules/user/actions.js
@@ -169,7 +169,7 @@ export const actions = {
             console.log('get_current_user', response);
 
             context.commit('initUser', response.data);
-            context.commit('set_default_litter_presence', response.data.items_remaining);
+            context.commit('set_default_litter_picked_up', response.data.picked_up);
         })
         .catch(error => {
             console.log('error.get_current_user', error);

--- a/resources/js/views/RootContainer.vue
+++ b/resources/js/views/RootContainer.vue
@@ -49,7 +49,7 @@ export default {
             {
                 const u = JSON.parse(this.user);
                 this.$store.commit('initUser', u);
-                this.$store.commit('set_default_litter_presence', u.items_remaining);
+                this.$store.commit('set_default_litter_picked_up', u.picked_up);
             }
         }
 

--- a/tests/Feature/Admin/CorrectTagsDeletePhotoTest.php
+++ b/tests/Feature/Admin/CorrectTagsDeletePhotoTest.php
@@ -55,7 +55,7 @@ class CorrectTagsDeletePhotoTest extends TestCase
 
         $this->post('/add-tags', [
             'photo_id' => $this->photo->id,
-            'presence' => true,
+            'picked_up' => false,
             'tags' => [
                 'smoking' => [
                     'butts' => 3

--- a/tests/Feature/Admin/CorrectTagsKeepPhotoTest.php
+++ b/tests/Feature/Admin/CorrectTagsKeepPhotoTest.php
@@ -54,7 +54,7 @@ class CorrectTagsKeepPhotoTest extends TestCase
 
         $this->post('/add-tags', [
             'photo_id' => $this->photo->id,
-            'presence' => true,
+            'picked_up' => false,
             'tags' => [
                 'smoking' => [
                     'butts' => 3

--- a/tests/Feature/Admin/DeletePhotoTest.php
+++ b/tests/Feature/Admin/DeletePhotoTest.php
@@ -59,7 +59,7 @@ class DeletePhotoTest extends TestCase
 
         $this->post('/add-tags', [
             'photo_id' => $this->photo->id,
-            'presence' => true,
+            'picked_up' => false,
             'tags' => [
                 'smoking' => [
                     'butts' => 3
@@ -125,7 +125,7 @@ class DeletePhotoTest extends TestCase
         // User tags the image
         $this->post('/add-tags', [
             'photo_id' => $this->photo->id,
-            'presence' => true,
+            'picked_up' => false,
             'tags' => ['smoking' => ['butts' => 3]]
         ]);
         $this->assertEquals(4, Redis::zscore("xp.users", $this->user->id));

--- a/tests/Feature/Admin/IncorrectTagsTest.php
+++ b/tests/Feature/Admin/IncorrectTagsTest.php
@@ -56,7 +56,7 @@ class IncorrectTagsTest extends TestCase
 
         $this->post('/add-tags', [
             'photo_id' => $this->photo->id,
-            'presence' => true,
+            'picked_up' => false,
             'tags' => [
                 'smoking' => [
                     'butts' => 3
@@ -102,7 +102,7 @@ class IncorrectTagsTest extends TestCase
         // User tags the image
         $this->post('/add-tags', [
             'photo_id' => $this->photo->id,
-            'presence' => true,
+            'picked_up' => false,
             'tags' => ['smoking' => ['butts' => 3]]
         ]);
         $this->assertEquals(4, Redis::zscore("xp.users", $this->user->id));
@@ -132,7 +132,7 @@ class IncorrectTagsTest extends TestCase
 
         $this->post('/add-tags', [
             'photo_id' => $this->photo->id,
-            'presence' => true,
+            'picked_up' => false,
             'tags' => [
                 'smoking' => [
                     'butts' => 3

--- a/tests/Feature/Admin/UpdateTagsDeletePhotoTest.php
+++ b/tests/Feature/Admin/UpdateTagsDeletePhotoTest.php
@@ -56,7 +56,7 @@ class UpdateTagsDeletePhotoTest extends TestCase
 
         $this->post('/add-tags', [
             'photo_id' => $this->photo->id,
-            'presence' => true,
+            'picked_up' => false,
             'tags' => [
                 'smoking' => [
                     'butts' => 3
@@ -142,7 +142,7 @@ class UpdateTagsDeletePhotoTest extends TestCase
         $this->assertEquals(11, $this->user->xp); // 1 xp from uploading, + 10xp from alcohol
 
         $this->assertEquals(10, $this->photo->total_litter);
-        $this->assertEquals(0, $this->photo->remaining);
+        $this->assertFalse($this->photo->picked_up);
         $this->assertEquals(1, $this->photo->verification);
         $this->assertEquals(2, $this->photo->verified);
     }

--- a/tests/Feature/Api/Teams/JoinTeamTest.php
+++ b/tests/Feature/Api/Teams/JoinTeamTest.php
@@ -150,7 +150,7 @@ class JoinTeamTest extends TestCase
         // User adds tags to the photo -------------------
         $this->post('/add-tags', [
             'photo_id' => $photo->id,
-            'presence' => true,
+            'picked_up' => false,
             'tags' => [
                 'smoking' => [
                     'butts' => 3

--- a/tests/Feature/Photos/AddCustomTagsToPhotoTest.php
+++ b/tests/Feature/Photos/AddCustomTagsToPhotoTest.php
@@ -44,7 +44,7 @@ class AddCustomTagsToPhotoTest extends TestCase
 
         $this->postJson('/add-tags', [
             'photo_id' => $photo->id,
-            'presence' => true,
+            'picked_up' => false,
             'custom_tags' => ['tag1', 'tag2', 'tag3']
         ])->assertOk();
 

--- a/tests/Feature/Photos/AddTagsToPhotoTest.php
+++ b/tests/Feature/Photos/AddTagsToPhotoTest.php
@@ -49,7 +49,7 @@ class AddTagsToPhotoTest extends TestCase
         // User adds tags to an image -------------------
         $this->post('/add-tags', [
             'photo_id' => $photo->id,
-            'presence' => true,
+            'picked_up' => true,
             'tags' => [
                 'smoking' => [
                     'butts' => 3
@@ -60,7 +60,7 @@ class AddTagsToPhotoTest extends TestCase
         // Assert tags are stored correctly ------------
         $photo->refresh();
 
-        $this->assertEquals(0, $photo->remaining);
+        $this->assertTrue($photo->picked_up);
         $this->assertNotNull($photo->smoking_id);
         $this->assertInstanceOf(Smoking::class, $photo->smoking);
         $this->assertEquals(3, $photo->smoking->butts);
@@ -84,7 +84,7 @@ class AddTagsToPhotoTest extends TestCase
         // User adds tags to an image -------------------
         $this->post('/add-tags', [
             'photo_id' => $photo->id,
-            'presence' => false,
+            'picked_up' => true,
             'tags' => [
                 'smoking' => [
                     'butts' => 3
@@ -101,7 +101,7 @@ class AddTagsToPhotoTest extends TestCase
 
         $this->assertEquals(9, $user->xp); // 1 xp from uploading, + 8xp from total litter tagged
         $this->assertEquals(8, $photo->total_litter);
-        $this->assertEquals(1, $photo->remaining);
+        $this->assertTrue($photo->picked_up);
         $this->assertEquals(0.1, $photo->verification);
     }
 
@@ -122,7 +122,7 @@ class AddTagsToPhotoTest extends TestCase
         // User adds tags to the verified photo -------------------
         $response = $this->post('/add-tags', [
             'photo_id' => $photo->id,
-            'presence' => false,
+            'picked_up' => true,
             'tags' => [
                 'smoking' => [
                     'butts' => 3
@@ -145,7 +145,7 @@ class AddTagsToPhotoTest extends TestCase
         // Missing photo_id -------------------
         $this->postJson('/add-tags', [
             'tags' => ['smoking' => ['butts' => 3]],
-            'presence' => true
+            'picked_up' => false
         ])
             ->assertStatus(422)
             ->assertJsonValidationErrors(['photo_id']);
@@ -154,7 +154,7 @@ class AddTagsToPhotoTest extends TestCase
         $this->postJson('/add-tags', [
             'photo_id' => 0,
             'tags' => ['smoking' => ['butts' => 3]],
-            'presence' => true
+            'picked_up' => false
         ])
             ->assertStatus(422)
             ->assertJsonValidationErrors(['photo_id']);
@@ -163,7 +163,7 @@ class AddTagsToPhotoTest extends TestCase
         $this->postJson('/add-tags', [
             'photo_id' => Photo::factory()->create()->id,
             'tags' => ['smoking' => ['butts' => 3]],
-            'presence' => true
+            'picked_up' => false
         ])
             ->assertForbidden();
     }
@@ -186,7 +186,7 @@ class AddTagsToPhotoTest extends TestCase
         $this->postJson('/add-tags', [
             'photo_id' => $photo->id,
             'tags' => [],
-            'presence' => true
+            'picked_up' => false
         ])
             ->assertStatus(422)
             ->assertJsonValidationErrors(['tags']);
@@ -195,13 +195,13 @@ class AddTagsToPhotoTest extends TestCase
         $this->postJson('/add-tags', [
             'photo_id' => $photo->id,
             'tags' => "asdf",
-            'presence' => true
+            'picked_up' => false
         ])
             ->assertStatus(422)
             ->assertJsonValidationErrors(['tags']);
     }
 
-    public function test_request_presence_is_validated()
+    public function test_request_picked_up_is_validated()
     {
         $user = User::factory()->create([
             'verification_required' => true
@@ -221,16 +221,16 @@ class AddTagsToPhotoTest extends TestCase
             'tags' => ['smoking' => ['butts' => 3]],
         ])
             ->assertStatus(422)
-            ->assertJsonValidationErrors(['presence']);
+            ->assertJsonValidationErrors(['picked_up']);
 
-        // presence is not a boolean -------------------
+        // picked_up is not a boolean -------------------
         $this->postJson('/add-tags', [
             'photo_id' => $photo->id,
             'tags' => ['smoking' => ['butts' => 3]],
-            'presence' => 'asdf'
+            'picked_up' => 'asdf'
         ])
             ->assertStatus(422)
-            ->assertJsonValidationErrors(['presence']);
+            ->assertJsonValidationErrors(['picked_up']);
     }
 
     public function test_it_fires_tags_verified_by_admin_event_when_a_verified_user_adds_tags_to_a_photo()
@@ -253,7 +253,7 @@ class AddTagsToPhotoTest extends TestCase
         // User adds tags to an image -------------------
         $this->post('/add-tags', [
             'photo_id' => $photo->id,
-            'presence' => false,
+            'picked_up' => true,
             'tags' => [
                 'smoking' => [
                     'butts' => 3
@@ -295,7 +295,7 @@ class AddTagsToPhotoTest extends TestCase
         // User adds tags to an image -------------------
         $this->post('/add-tags', [
             'photo_id' => $photo->id,
-            'presence' => true,
+            'picked_up' => false,
             'tags' => ['smoking' => ['butts' => 3]]
         ])->assertOk();
 

--- a/tests/Feature/Teams/JoinTeamTest.php
+++ b/tests/Feature/Teams/JoinTeamTest.php
@@ -151,7 +151,7 @@ class JoinTeamTest extends TestCase
         // User adds tags to the photo -------------------
         $this->post('/add-tags', [
             'photo_id' => $photo->id,
-            'presence' => true,
+            'picked_up' => false,
             'tags' => [
                 'smoking' => [
                     'butts' => 3

--- a/tests/Feature/Teams/TrustedTeamsTest.php
+++ b/tests/Feature/Teams/TrustedTeamsTest.php
@@ -48,7 +48,7 @@ class TrustedTeamsTest extends TestCase
 
         $this->post('/add-tags', [
             'photo_id' => $photo->id,
-            'presence' => false,
+            'picked_up' => true,
             'tags' => ['smoking' => ['butts' => 3]]
         ]);
 


### PR DESCRIPTION
https://trello.com/c/4MrINi2b
https://trello.com/c/KtCqRTrq

The issue was that when getting the features on the GlobalMapController, we didn't include the 'remaining' column, so the 'picked up' value always defaulted to true.

I also removed the last month from the stats on the Community page, since it's always 0.

We also skip the 'All Time' clustering if there are no new photos uploaded recently for any year.