### PR TITLE
Feature - Reward Admins with XP

### DIFF
--- a/app/Actions/CalculateTagsDifferenceAction.php
+++ b/app/Actions/CalculateTagsDifferenceAction.php
@@ -4,6 +4,12 @@ namespace App\Actions;
 
 class CalculateTagsDifferenceAction
 {
+    /**
+     * Calculates the diff between the existing user tags
+     * and the tags provided by an admin
+     *
+     * todo refactor into returning a Value Object
+     */
     public function run(array $oldTags, array $newTags, array $oldCustomTags, array $newCustomTags): array
     {
         $tagsDiff = $this->tagsDiff($oldTags, $newTags);

--- a/app/Actions/CalculateTagsDifferenceAction.php
+++ b/app/Actions/CalculateTagsDifferenceAction.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Actions;
+
+class CalculateTagsDifferenceAction
+{
+    public function run(array $oldTags, array $newTags): array
+    {
+        $addedTags = array_diff_assoc_recursive($newTags, $oldTags);
+        $removedTags = array_diff_assoc_recursive($oldTags, $newTags);
+        $removedUserXp = 0;
+        $rewardedAdminXp = 0;
+
+        foreach ($addedTags as $category => $tags) {
+            foreach ($tags as $tag => $adminCount) {
+                // This means we have changed a tag count
+                if (isset($removedTags[$category][$tag])) {
+                    $userCount = $removedTags[$category][$tag];
+                    if ($adminCount < $userCount) {
+                        $removedUserXp += $userCount - $adminCount;
+                    }
+                }
+
+                $rewardedAdminXp += 1;
+            }
+        }
+
+        foreach ($removedTags as $category => $tags) {
+            foreach ($tags as $tag => $userCount) {
+                // This means we have deleted a tag entirely
+                if (!isset($addedTags[$category][$tag])) {
+                    $removedUserXp += $userCount;
+                    $rewardedAdminXp += 1;
+                }
+            }
+        }
+
+        return [
+            'added' => $addedTags,
+            'removed' => $removedTags,
+            'removedUserXp' => $removedUserXp,
+            'rewardedAdminXp' => $rewardedAdminXp
+        ];
+    }
+}

--- a/app/Actions/CalculateTagsDifferenceAction.php
+++ b/app/Actions/CalculateTagsDifferenceAction.php
@@ -4,7 +4,20 @@ namespace App\Actions;
 
 class CalculateTagsDifferenceAction
 {
-    public function run(array $oldTags, array $newTags): array
+    public function run(array $oldTags, array $newTags, array $oldCustomTags, array $newCustomTags): array
+    {
+        $tagsDiff = $this->tagsDiff($oldTags, $newTags);
+        $customTagsDiff = $this->customTagsDiff($oldCustomTags, $newCustomTags);
+
+        return [
+            'added' => ['tags' => $tagsDiff['added'], 'customTags' => $customTagsDiff['added']],
+            'removed' => ['tags' => $tagsDiff['removed'], 'customTags' => $customTagsDiff['removed']],
+            'removedUserXp' => $tagsDiff['removedUserXp'] + $customTagsDiff['removedUserXp'],
+            'rewardedAdminXp' => $tagsDiff['rewardedAdminXp'] + $customTagsDiff['rewardedAdminXp']
+        ];
+    }
+
+    private function tagsDiff(array $oldTags, array $newTags): array
     {
         $addedTags = array_diff_assoc_recursive($newTags, $oldTags);
         $removedTags = array_diff_assoc_recursive($oldTags, $newTags);
@@ -34,6 +47,22 @@ class CalculateTagsDifferenceAction
                 }
             }
         }
+
+        return [
+            'added' => $addedTags,
+            'removed' => $removedTags,
+            'removedUserXp' => $removedUserXp,
+            'rewardedAdminXp' => $rewardedAdminXp
+        ];
+    }
+
+    private function customTagsDiff(array $oldTags, array $newTags): array
+    {
+        $addedTags = array_diff($newTags, $oldTags);
+        $removedTags = array_diff($oldTags, $newTags);
+
+        $removedUserXp = count($removedTags);
+        $rewardedAdminXp = count($addedTags) + count($removedTags);
 
         return [
             'added' => $addedTags,

--- a/app/Actions/LogAdminVerificationAction.php
+++ b/app/Actions/LogAdminVerificationAction.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\AdminVerificationLog;
+use App\Models\Photo;
+use App\Models\User\User;
+
+class LogAdminVerificationAction
+{
+    /**
+     * Stores the action that an admin takes on the photo verification page
+     * The stored rewarded_admin_xp can be used to restore admins' xp
+     * in case their data is lost and xp needs to be recalculated
+     */
+    public function run(
+        User $admin,
+        Photo $photo,
+        string $action,
+        array $addedTags,
+        array $removedTags,
+        int $rewardedAdminXp,
+        int $removedUserXp
+    ) {
+        AdminVerificationLog::create([
+            'admin_id' => $admin->id,
+            'photo_id' => $photo->id,
+            'action' => $action,
+            'added_tags' => $addedTags,
+            'removed_tags' => $removedTags,
+            'rewarded_admin_xp' => $rewardedAdminXp,
+            'removed_user_xp' => $removedUserXp
+        ]);
+    }
+}

--- a/app/Helpers/helpers.php
+++ b/app/Helpers/helpers.php
@@ -1,0 +1,30 @@
+<?php
+if (!function_exists('array_diff_assoc_recursive')) {
+    /**
+     * Computes the difference of arrays with additional index check, recursively.
+     * @see https://www.php.net/manual/en/function.array-diff-assoc.php#111675
+     *
+     * @param array $array1
+     * @param array $array2
+     * @return array
+     */
+    function array_diff_assoc_recursive(array $array1, array $array2): array
+    {
+        $difference = [];
+        foreach ($array1 as $key => $value) {
+            if (is_array($value)) {
+                if (!isset($array2[$key]) || !is_array($array2[$key])) {
+                    $difference[$key] = $value;
+                } else {
+                    $new_diff = array_diff_assoc_recursive($value, $array2[$key]);
+                    if (!empty($new_diff)) {
+                        $difference[$key] = $new_diff;
+                    }
+                }
+            } else if (!array_key_exists($key, $array2) || $array2[$key] !== $value) {
+                $difference[$key] = $value;
+            }
+        }
+        return $difference;
+    }
+}

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -123,7 +123,7 @@ class AdminController extends Controller
 
         $this->rewardXpToAdmin();
 
-        $this->logAdminAction($photo, Route::getCurrentRoute()->getActionName());
+        $this->logAdminAction($photo, Route::getCurrentRoute()->getActionMethod());
 
         event (new TagsVerifiedByAdmin($photo->id));
     }
@@ -143,7 +143,7 @@ class AdminController extends Controller
 
         $this->rewardXpToAdmin();
 
-        $this->logAdminAction($photo, Route::getCurrentRoute()->getActionName());
+        $this->logAdminAction($photo, Route::getCurrentRoute()->getActionMethod());
 
         event (new TagsVerifiedByAdmin($photo->id));
     }
@@ -179,7 +179,7 @@ class AdminController extends Controller
 
         $this->rewardXpToAdmin();
 
-        $this->logAdminAction($photo, Route::getCurrentRoute()->getActionName(), $tagUpdates);
+        $this->logAdminAction($photo, Route::getCurrentRoute()->getActionMethod(), $tagUpdates);
 
         return ['success' => true];
     }
@@ -202,7 +202,7 @@ class AdminController extends Controller
             []
         );
 
-        $this->logAdminAction($photo, Route::getCurrentRoute()->getActionName(), $tagUpdates);
+        $this->logAdminAction($photo, Route::getCurrentRoute()->getActionMethod(), $tagUpdates);
 
         $this->deleteTagsAction->run($photo);
 
@@ -247,11 +247,11 @@ class AdminController extends Controller
         $photo->save();
 
         // TODO categories and custom_tags are not provided in the front-end
-        $tagUpdates = $this->addTags($request->categories, $request->custom_tags ?? [], $photo->id);
+        $tagUpdates = $this->addTags($request->categories ?? [], $request->custom_tags ?? [], $photo->id);
 
         $this->rewardXpToAdmin(1 + $tagUpdates['rewardedAdminXp']);
 
-        $this->logAdminAction($photo, Route::getCurrentRoute()->getActionName(), $tagUpdates);
+        $this->logAdminAction($photo, Route::getCurrentRoute()->getActionMethod(), $tagUpdates);
 
         event(new TagsVerifiedByAdmin($photo->id));
     }
@@ -279,7 +279,7 @@ class AdminController extends Controller
 
         $this->rewardXpToAdmin(1 + $tagUpdates['rewardedAdminXp']);
 
-        $this->logAdminAction($photo, Route::getCurrentRoute()->getActionName(), $tagUpdates);
+        $this->logAdminAction($photo, Route::getCurrentRoute()->getActionMethod(), $tagUpdates);
 
         event (new TagsVerifiedByAdmin($photo->id));
     }

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -156,7 +156,12 @@ class AdminController extends Controller
         $photo->result_string = null;
         $photo->save();
 
-        $tagUpdates = $this->calculateTagsDiffAction->run($photo->tags(), []);
+        $tagUpdates = $this->calculateTagsDiffAction->run(
+            $photo->tags(),
+            [],
+            $photo->customTags->pluck('tag')->toArray(),
+            []
+        );
         $this->deleteTagsAction->run($photo);
 
         $user = User::find($photo->user_id);
@@ -182,7 +187,12 @@ class AdminController extends Controller
 
         $this->deletePhotoAction->run($photo);
 
-        $tagUpdates = $this->calculateTagsDiffAction->run($photo->tags(), []);
+        $tagUpdates = $this->calculateTagsDiffAction->run(
+            $photo->tags(),
+            [],
+            $photo->customTags->pluck('tag')->toArray(),
+            []
+        );
 
         $this->deleteTagsAction->run($photo);
 

--- a/app/Http/Controllers/Bbox/BoundingBoxController.php
+++ b/app/Http/Controllers/Bbox/BoundingBoxController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Bbox;
 
+use App\Actions\CalculateTagsDifferenceAction;
 use App\Events\TagsVerifiedByAdmin;
 use App\Litterrata;
 use App\Models\AI\Annotation;
@@ -14,6 +15,17 @@ use App\Http\Controllers\Controller;
 class BoundingBoxController extends Controller
 {
     use AddTagsTrait;
+
+    /** @var CalculateTagsDifferenceAction */
+    protected $calculateTagsDiffAction;
+
+    /**
+     * @param CalculateTagsDifferenceAction $calculateTagsDiffAction
+     */
+    public function __construct(CalculateTagsDifferenceAction $calculateTagsDiffAction)
+    {
+        $this->calculateTagsDiffAction = $calculateTagsDiffAction;
+    }
 
     /**
      * Add bounding boxes to an image

--- a/app/Models/AdminVerificationLog.php
+++ b/app/Models/AdminVerificationLog.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AdminVerificationLog extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'added_tags' => 'array',
+        'removed_tags' => 'array'
+    ];
+}

--- a/app/Models/Photo.php
+++ b/app/Models/Photo.php
@@ -163,8 +163,9 @@ class Photo extends Model
      *
      * Remove any keys with null values
      */
-    public function tags ()
+    public function tags (): array
     {
+        $tags = [];
         foreach ($this->categories() as $category)
         {
             if ($this->$category)
@@ -175,9 +176,15 @@ class Photo extends Model
                     {
                         unset ($this->$category[$tag]);
                     }
+                    else
+                    {
+                        $tags[$category][$tag] = $this->$category[$tag];
+                    }
                 }
             }
         }
+
+        return $tags;
     }
 
     /**

--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -25,6 +25,7 @@ use LaravelAndVueJS\Traits\LaravelPermissionToVueJS;
  * @property array<Team> $teams
  * @property Team $team
  * @property int $active_team
+ * @property int $xp
  * @property int $xp_redis
  */
 class User extends Authenticatable

--- a/app/Traits/AddTagsTrait.php
+++ b/app/Traits/AddTagsTrait.php
@@ -24,7 +24,12 @@ trait AddTagsTrait
         /** @var User $photo */
         $user = User::find($photo->user_id);
 
-        $tagUpdates = $this->calculateTagsDiffAction->run($photo->tags(), $tags);
+        $tagUpdates = $this->calculateTagsDiffAction->run(
+            $photo->tags(),
+            $tags,
+            $photo->customTags->pluck('tag')->toArray(),
+            $customTags
+        );
 
         // Delete the old tags
         /** @var DeleteTagsFromPhotoAction $deleteTagsAction */

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,9 @@
         }
     },
     "autoload": {
+        "files": [
+            "app/Helpers/helpers.php"
+        ],
         "psr-4": {
             "App\\": "app/"
         },

--- a/database/migrations/2022_03_24_123909_create_admin_verification_logs_table.php
+++ b/database/migrations/2022_03_24_123909_create_admin_verification_logs_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateAdminVerificationLogsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('admin_verification_logs', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('admin_id');
+            $table->unsignedInteger('photo_id');
+            $table->string('action');
+            $table->json('added_tags');
+            $table->json('removed_tags');
+            $table->integer('rewarded_admin_xp');
+            $table->integer('removed_user_xp');
+            $table->timestamps();
+
+            $table->foreign('admin_id')->references('id')->on('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('admin_verification_logs');
+    }
+}

--- a/tests/Feature/Admin/CorrectTagsDeletePhotoTest.php
+++ b/tests/Feature/Admin/CorrectTagsDeletePhotoTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Admin;
 
 
+use App\Actions\LogAdminVerificationAction;
 use App\Events\TagsVerifiedByAdmin;
 use App\Models\Photo;
 use App\Models\User\User;
@@ -141,5 +142,15 @@ class CorrectTagsDeletePhotoTest extends TestCase
                 return $e->photo_id === $this->photo->id;
             }
         );
+    }
+
+    public function test_it_logs_the_admin_action()
+    {
+        $spy = $this->spy(LogAdminVerificationAction::class);
+
+        $this->actingAs($this->admin)
+            ->post('/admin/verify', ['photoId' => $this->photo->id]);
+
+        $spy->shouldHaveReceived('run');
     }
 }

--- a/tests/Feature/Admin/CorrectTagsKeepPhotoTest.php
+++ b/tests/Feature/Admin/CorrectTagsKeepPhotoTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Admin;
 
 
+use App\Actions\LogAdminVerificationAction;
 use App\Events\TagsVerifiedByAdmin;
 use App\Models\Litter\Categories\Smoking;
 use App\Models\Photo;
@@ -139,5 +140,16 @@ class CorrectTagsKeepPhotoTest extends TestCase
                 return $e->photo_id === $this->photo->id;
             }
         );
+    }
+
+
+    public function test_it_logs_the_admin_action()
+    {
+        $spy = $this->spy(LogAdminVerificationAction::class);
+
+        $this->actingAs($this->admin)
+            ->post('/admin/verifykeepimage', ['photoId' => $this->photo->id]);
+
+        $spy->shouldHaveReceived('run');
     }
 }

--- a/tests/Feature/Admin/CorrectTagsKeepPhotoTest.php
+++ b/tests/Feature/Admin/CorrectTagsKeepPhotoTest.php
@@ -8,6 +8,7 @@ use App\Models\Litter\Categories\Smoking;
 use App\Models\Photo;
 use App\Models\User\User;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Redis;
 use Illuminate\Support\Facades\Storage;
 use Spatie\Permission\Models\Role;
 use Tests\Feature\HasPhotoUploads;
@@ -68,7 +69,10 @@ class CorrectTagsKeepPhotoTest extends TestCase
     public function test_an_admin_can_mark_photos_as_correctly_tagged()
     {
         // We make sure xp and tags are correct
+        Redis::zrem('xp.users', $this->admin->id);
         $this->assertEquals(4, $this->user->xp);
+        $this->assertEquals(0, $this->admin->xp);
+        $this->assertEquals(0, $this->admin->xp_redis);
         $this->assertInstanceOf(Smoking::class, $this->photo->smoking);
 
         // Admin marks the tagging as correct -------------------
@@ -86,6 +90,9 @@ class CorrectTagsKeepPhotoTest extends TestCase
         $this->assertEquals(2, $this->photo->verified);
         $this->assertEquals(3, $this->photo->total_litter);
         $this->assertInstanceOf(Smoking::class, $this->photo->smoking);
+        // Admin is rewarded with 1 XP
+        $this->assertEquals(1, $this->admin->xp);
+        $this->assertEquals(1, $this->admin->xp_redis);
     }
 
     public function test_unauthorized_users_cannot_mark_tagging_as_correct()

--- a/tests/Feature/Admin/DeletePhotoTest.php
+++ b/tests/Feature/Admin/DeletePhotoTest.php
@@ -72,6 +72,7 @@ class DeletePhotoTest extends TestCase
         // We make sure the photo exists
         Storage::disk('s3')->assertExists($this->imageAndAttributes['filepath']);
         Storage::disk('bbox')->assertExists($this->imageAndAttributes['filepath']);
+        $this->assertEquals(0, $this->admin->xp);
         $this->assertEquals(1, $this->user->has_uploaded);
         $this->assertEquals(4, $this->user->xp);
         $this->assertEquals(1, $this->user->total_images);
@@ -84,6 +85,8 @@ class DeletePhotoTest extends TestCase
 
         $this->user->refresh();
 
+        // Admin is rewarded with 1 XP
+        $this->assertEquals(1, $this->admin->xp);
         // And it's gone
         $this->assertEquals(1, $this->user->has_uploaded); // TODO shouldn't it decrement?
         $this->assertEquals(0, $this->user->xp);
@@ -118,6 +121,7 @@ class DeletePhotoTest extends TestCase
     public function test_leaderboards_are_updated_when_an_admin_deletes_a_photo()
     {
         // User has already uploaded an image, so their xp is 1
+        Redis::zrem('xp.users', $this->admin->id);
         Redis::zadd("xp.users", 1, $this->user->id);
         Redis::zadd("xp.country.{$this->photo->country_id}", 1, $this->user->id);
         Redis::zadd("xp.country.{$this->photo->country_id}.state.{$this->photo->state_id}", 1, $this->user->id);
@@ -128,6 +132,7 @@ class DeletePhotoTest extends TestCase
             'picked_up' => false,
             'tags' => ['smoking' => ['butts' => 3]]
         ]);
+        $this->assertEquals(0, $this->admin->xp_redis);
         $this->assertEquals(4, Redis::zscore("xp.users", $this->user->id));
         $this->assertEquals(4, Redis::zscore("xp.country.{$this->photo->country_id}", $this->user->id));
         $this->assertEquals(4, Redis::zscore("xp.country.{$this->photo->country_id}.state.{$this->photo->state_id}", $this->user->id));
@@ -137,6 +142,7 @@ class DeletePhotoTest extends TestCase
         $this->actingAs($this->admin)->post('/admin/destroy', ['photoId' => $this->photo->id]);
 
         // Assert leaderboards are updated ------------
+        $this->assertEquals(1, $this->admin->xp_redis);
         $this->assertEquals(0, Redis::zscore("xp.users", $this->user->id));
         $this->assertEquals(0, Redis::zscore("xp.country.{$this->photo->country_id}", $this->user->id));
         $this->assertEquals(0, Redis::zscore("xp.country.{$this->photo->country_id}.state.{$this->photo->state_id}", $this->user->id));

--- a/tests/Feature/Admin/DeletePhotoTest.php
+++ b/tests/Feature/Admin/DeletePhotoTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Admin;
 
 
+use App\Actions\LogAdminVerificationAction;
 use App\Events\ImageDeleted;
 use App\Models\Photo;
 use App\Models\User\User;
@@ -175,5 +176,15 @@ class DeletePhotoTest extends TestCase
         $response = $this->post('/admin/destroy', ['photoId' => 0]);
 
         $response->assertNotFound();
+    }
+
+    public function test_it_logs_the_admin_action()
+    {
+        $spy = $this->spy(LogAdminVerificationAction::class);
+
+        $this->actingAs($this->admin)
+            ->post('/admin/destroy', ['photoId' => $this->photo->id]);
+
+        $spy->shouldHaveReceived('run');
     }
 }

--- a/tests/Feature/Admin/IncorrectTagsTest.php
+++ b/tests/Feature/Admin/IncorrectTagsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Admin;
 
 
+use App\Actions\LogAdminVerificationAction;
 use App\Models\Litter\Categories\Smoking;
 use App\Models\Photo;
 use App\Models\User\User;
@@ -165,5 +166,16 @@ class IncorrectTagsTest extends TestCase
         $response = $this->post('/admin/incorrect', ['photoId' => 0]);
 
         $response->assertNotFound();
+    }
+
+
+    public function test_it_logs_the_admin_action()
+    {
+        $spy = $this->spy(LogAdminVerificationAction::class);
+
+        $this->actingAs($this->admin)
+            ->post('/admin/incorrect', ['photoId' => $this->photo->id]);
+
+        $spy->shouldHaveReceived('run');
     }
 }

--- a/tests/Feature/Admin/UpdateTagsDeletePhotoTest.php
+++ b/tests/Feature/Admin/UpdateTagsDeletePhotoTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Admin;
 
+use App\Actions\LogAdminVerificationAction;
 use App\Events\TagsVerifiedByAdmin;
 use App\Models\Litter\Categories\Alcohol;
 use App\Models\Location\City;
@@ -185,6 +186,24 @@ class UpdateTagsDeletePhotoTest extends TestCase
                 return $e->photo_id === $this->photo->id;
             }
         );
+    }
+
+    /**
+     * @dataProvider provider
+     */
+    public function test_it_logs_the_admin_action(
+        $route, $deletesPhoto, $tagsKey
+    )
+    {
+        $spy = $this->spy(LogAdminVerificationAction::class);
+
+        $this->actingAs($this->admin)
+            ->post($route, [
+                'photoId' => $this->photo->id,
+                $tagsKey => ['alcohol' => ['beerBottle' => 10]]
+            ]);
+
+        $spy->shouldHaveReceived('run');
     }
 
     /**

--- a/tests/Feature/Admin/UpdateTagsDeletePhotoTest.php
+++ b/tests/Feature/Admin/UpdateTagsDeletePhotoTest.php
@@ -145,8 +145,10 @@ class UpdateTagsDeletePhotoTest extends TestCase
         $this->user->refresh();
         $this->photo->refresh();
 
-        // Admin is rewarded with 1 XP for the effort + 1xp for deleting tag + 2xp for adding new tag + custom tag
-        $this->assertEquals(4, $this->admin->xp);
+        // Admin is rewarded with 1 XP for the effort
+        // + 2xp for deleting tag and custom tag
+        // + 2xp for adding new tag + custom tag
+        $this->assertEquals(5, $this->admin->xp);
         // 1 xp from uploading, xp from other tags is removed
         $this->assertEquals(1, $this->user->xp);
         $this->assertEquals(10, $this->photo->total_litter);
@@ -195,9 +197,9 @@ class UpdateTagsDeletePhotoTest extends TestCase
         // User has already uploaded and tagged the image, so their xp is 5
         Redis::zrem('xp.users', $this->admin->id);
         Redis::zadd("xp.users", 5, $this->user->id);
-        Redis::zadd("xp.country.{$this->photo->country_id}", 4, $this->user->id);
-        Redis::zadd("xp.country.{$this->photo->country_id}.state.{$this->photo->state_id}", 4, $this->user->id);
-        Redis::zadd("xp.country.{$this->photo->country_id}.state.{$this->photo->state_id}.city.{$this->photo->city_id}", 4, $this->user->id);
+        Redis::zadd("xp.country.{$this->photo->country_id}", 5, $this->user->id);
+        Redis::zadd("xp.country.{$this->photo->country_id}.state.{$this->photo->state_id}", 5, $this->user->id);
+        Redis::zadd("xp.country.{$this->photo->country_id}.state.{$this->photo->state_id}.city.{$this->photo->city_id}", 5, $this->user->id);
 
         $this->assertEquals(0, $this->admin->xp_redis);
 
@@ -211,7 +213,7 @@ class UpdateTagsDeletePhotoTest extends TestCase
         ]);
 
         // Assert leaderboards are updated ------------
-        $this->assertEquals(4, $this->admin->xp_redis);
+        $this->assertEquals(5, $this->admin->xp_redis);
         $this->assertEquals(1, Redis::zscore("xp.users", $this->user->id));
         $this->assertEquals(1, Redis::zscore("xp.country.{$this->photo->country_id}", $this->user->id));
         $this->assertEquals(1, Redis::zscore("xp.country.{$this->photo->country_id}.state.{$this->photo->state_id}", $this->user->id));

--- a/tests/Feature/Admin/UpdateTagsDeletePhotoTest.php
+++ b/tests/Feature/Admin/UpdateTagsDeletePhotoTest.php
@@ -141,8 +141,8 @@ class UpdateTagsDeletePhotoTest extends TestCase
         $this->user->refresh();
         $this->photo->refresh();
 
-        // Admin is rewarded with 1 XP
-        $this->assertEquals(1, $this->admin->xp);
+        // Admin is rewarded with 1 XP for the effort + 1xp for deleting tag + 1xp for adding new tag
+        $this->assertEquals(3, $this->admin->xp);
         $this->assertEquals(11, $this->user->xp); // 1 xp from uploading, + 10xp from alcohol
         $this->assertEquals(10, $this->photo->total_litter);
         $this->assertFalse($this->photo->picked_up);
@@ -205,7 +205,7 @@ class UpdateTagsDeletePhotoTest extends TestCase
         ]);
 
         // Assert leaderboards are updated ------------
-        $this->assertEquals(1, $this->admin->xp_redis);
+        $this->assertEquals(3, $this->admin->xp_redis);
         $this->assertEquals(11, Redis::zscore("xp.users", $this->user->id));
         $this->assertEquals(11, Redis::zscore("xp.country.{$this->photo->country_id}", $this->user->id));
         $this->assertEquals(11, Redis::zscore("xp.country.{$this->photo->country_id}.state.{$this->photo->state_id}", $this->user->id));

--- a/tests/Unit/Actions/CalculateTagsDifferenceActionTest.php
+++ b/tests/Unit/Actions/CalculateTagsDifferenceActionTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Actions;
+
+use App\Actions\CalculateTagsDifferenceAction;
+use Tests\TestCase;
+
+class CalculateTagsDifferenceActionTest extends TestCase
+{
+    public function tagsDataProvider(): array
+    {
+        return [
+            'add new tag' => [
+                'oldTags' => [],
+                'newTags' => ['smoking' => ['butts' => 3]],
+                'removed' => [],
+                'added' => ['smoking' => ['butts' => 3]],
+                'removedUserXp' => 0,
+                'rewardedAdminXp' => 1
+            ],
+            'increment user tag' => [
+                'oldTags' => ['smoking' => ['butts' => 3]],
+                'newTags' => ['smoking' => ['butts' => 10]],
+                'removed' => ['smoking' => ['butts' => 3]],
+                'added' => ['smoking' => ['butts' => 10]],
+                'removedUserXp' => 0,
+                'rewardedAdminXp' => 1
+            ],
+            'decrement user tag' => [
+                'oldTags' => ['smoking' => ['butts' => 3]],
+                'newTags' => ['smoking' => ['butts' => 1]],
+                'removed' => ['smoking' => ['butts' => 3]],
+                'added' => ['smoking' => ['butts' => 1]],
+                'removedUserXp' => 2,
+                'rewardedAdminXp' => 1
+            ],
+            'delete user tag' => [
+                'oldTags' => ['smoking' => ['butts' => 3]],
+                'newTags' => ['smoking' => ['lighters' => 5]],
+                'removed' => ['smoking' => ['butts' => 3]],
+                'added' => ['smoking' => ['lighters' => 5]],
+                'removedUserXp' => 3,
+                'rewardedAdminXp' => 2
+            ],
+            'add, delete, incr, decr tags' => [
+                'oldTags' => ['smoking' => ['butts' => 3, 'lighters' => 1]],
+                'newTags' => ['smoking' => ['butts' => 1], 'alcohol' => ['beerBottle' => 2]],
+                'removed' => ['smoking' => ['butts' => 3, 'lighters' => 1]],
+                'added' => ['smoking' => ['butts' => 1], 'alcohol' => ['beerBottle' => 2]],
+                'removedUserXp' => 3,
+                'rewardedAdminXp' => 3
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider tagsDataProvider
+     */
+    public function test_run($oldTags, $newTags, $removed, $added, $removedUserXp, $rewardedAdminXp)
+    {
+        /** @var CalculateTagsDifferenceAction $action */
+        $action = app(CalculateTagsDifferenceAction::class);
+        $result = $action->run($oldTags, $newTags);
+
+        $this->assertEquals($removed, $result['removed']);
+        $this->assertEquals($added, $result['added']);
+        $this->assertEquals($removedUserXp, $result['removedUserXp']);
+        $this->assertEquals($rewardedAdminXp, $result['rewardedAdminXp']);
+    }
+}

--- a/tests/Unit/Actions/CalculateTagsDifferenceActionTest.php
+++ b/tests/Unit/Actions/CalculateTagsDifferenceActionTest.php
@@ -53,17 +53,54 @@ class CalculateTagsDifferenceActionTest extends TestCase
         ];
     }
 
+    public function customTagsDataProvider(): array
+    {
+        return [
+            'add new tag' => [
+                'oldTags' => [],
+                'newTags' => ['smokingggg'],
+                'removed' => [],
+                'added' => ['smokingggg'],
+                'removedUserXp' => 0,
+                'rewardedAdminXp' => 1
+            ],
+            'delete user tag' => [
+                'oldTags' => ['smokingggg', 'testtt'],
+                'newTags' => ['lighters'],
+                'removed' => ['smokingggg', 'testtt'],
+                'added' => ['lighters'],
+                'removedUserXp' => 2,
+                'rewardedAdminXp' => 3
+            ]
+        ];
+    }
+
     /**
      * @dataProvider tagsDataProvider
      */
-    public function test_run($oldTags, $newTags, $removed, $added, $removedUserXp, $rewardedAdminXp)
+    public function test_it_calculates_tags_diff($oldTags, $newTags, $removed, $added, $removedUserXp, $rewardedAdminXp)
     {
         /** @var CalculateTagsDifferenceAction $action */
         $action = app(CalculateTagsDifferenceAction::class);
-        $result = $action->run($oldTags, $newTags);
+        $result = $action->run($oldTags, $newTags, [], []);
 
-        $this->assertEquals($removed, $result['removed']);
-        $this->assertEquals($added, $result['added']);
+        $this->assertEquals($removed, $result['removed']['tags']);
+        $this->assertEquals($added, $result['added']['tags']);
+        $this->assertEquals($removedUserXp, $result['removedUserXp']);
+        $this->assertEquals($rewardedAdminXp, $result['rewardedAdminXp']);
+    }
+
+    /**
+     * @dataProvider customTagsDataProvider
+     */
+    public function test_it_calculates_custom_tags_diff($oldTags, $newTags, $removed, $added, $removedUserXp, $rewardedAdminXp)
+    {
+        /** @var CalculateTagsDifferenceAction $action */
+        $action = app(CalculateTagsDifferenceAction::class);
+        $result = $action->run([], [], $oldTags, $newTags);
+
+        $this->assertEquals($removed, $result['removed']['customTags']);
+        $this->assertEquals($added, $result['added']['customTags']);
         $this->assertEquals($removedUserXp, $result['removedUserXp']);
         $this->assertEquals($rewardedAdminXp, $result['rewardedAdminXp']);
     }

--- a/tests/Unit/Actions/LogAdminVerificationActionTest.php
+++ b/tests/Unit/Actions/LogAdminVerificationActionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Actions;
+
+use App\Actions\LogAdminVerificationAction;
+use App\Models\AdminVerificationLog;
+use App\Models\Photo;
+use App\Models\User\User;
+use Tests\TestCase;
+
+class LogAdminVerificationActionTest extends TestCase
+{
+    public function test_it_logs_an_admins_action()
+    {
+        /** @var User $admin */
+        $admin = User::factory()->create();
+        /** @var Photo $photo */
+        $photo = Photo::factory()->create();
+        $addedTags = [
+            'tags' => ['smoking' => ['butts' => 3]],
+            'customTags' => 'nice-tag'
+        ];
+        $removedTags = [
+            'tags' => ['smoking' => ['lighters' => 1]],
+            'customTags' => 'tag'
+        ];
+        $removedUserXp = 100;
+        $rewardedAdminXp = 50;
+
+        /** @var LogAdminVerificationAction $action */
+        $action = app(LogAdminVerificationAction::class);
+        $action->run(
+            $admin,
+            $photo,
+            'verifycorrect',
+            $addedTags,
+            $removedTags,
+            $rewardedAdminXp,
+            $removedUserXp
+        );
+
+        $log = AdminVerificationLog::first();
+        $this->assertInstanceOf(AdminVerificationLog::class, $log);
+        $this->assertEquals($addedTags, $log->added_tags);
+        $this->assertEquals($removedTags, $log->removed_tags);
+        $this->assertEquals($removedUserXp, $log->removed_user_xp);
+        $this->assertEquals($rewardedAdminXp, $log->rewarded_admin_xp);
+    }
+}


### PR DESCRIPTION
https://trello.com/c/9ZTIZkvm

To reward admins, we compare the initial set of tags the user has submitted with the tags we have when an admin submits them.
So, to summarize:
- 1xp for every action an admin does (verify, verify & delete, delete, update tags, etc)
- 1xp for every changed tag, regardless of count. This means 1xp when adding a new tag, deleting a user tag, or incrementing/decrementing a user tag
This means if you do all possible actions (add new tag + delete tag + increment count + decrement count + click the Update with Tags button) you get max 5xp.

We also take custom tags into consideration, an admin gets 1xp for every tag they add or delete.

To be able to record the admins' actions and have some proof of their contributions, we have a new table 'admin_verification_logs' that records the action, the updated tags, and the xp rewarded to the admin from tag updates.

To setup: 'composer du' and 'php artisan migrate'.