### PR TITLE
Fixed custom tags suggestions name collision

### DIFF
--- a/resources/js/components/Litter/AddTags.vue
+++ b/resources/js/components/Litter/AddTags.vue
@@ -224,7 +224,7 @@ export default {
 
             results = results.concat(this.recentCustomTags.map(tag => {
                 return {
-                    key: tag,
+                    key: 'custom-' + tag,
                     title: tag,
                     custom: true
                 };
@@ -534,7 +534,7 @@ export default {
         search (input)
         {
             if (input.custom) {
-                this.addCustomTag(input.key);
+                this.addCustomTag(input.title);
             } else {
                 let searchValues = input.key.split(':');
 


### PR DESCRIPTION
Fixes the errors when adding a custom tag that already has a regular tag with the same key.
Simply updates the custom tag keys with the string 'custom-' so that there are no collisions with the regular tags.