### PR TITLE
Fix Profile Map: Add orderBy to photos request to order data by created_at or datetime

### DIFF
--- a/app/Http/Controllers/User/ProfileController.php
+++ b/app/Http/Controllers/User/ProfileController.php
@@ -87,6 +87,7 @@ class ProfileController extends Controller
             ])
             ->whereDate(request()->period, '>=', request()->start)
             ->whereDate(request()->period, '<=', request()->end)
+            ->orderBy(request()->period, 'asc')
             ->get();
 
         // Populate geojson object


### PR DESCRIPTION
[Trello card](https://trello.com/c/s2aGLLaq/516-profilepage-animation-the-right-pictures-are-shown-but-in-the-wrong-order-shown-in-uploaded-order-instead-of-taken-order)